### PR TITLE
feat: expand admin console with dashboards, APIs, and schema updates

### DIFF
--- a/app/(protected)/admin/layout.tsx
+++ b/app/(protected)/admin/layout.tsx
@@ -9,7 +9,6 @@ type Props = { children: ReactNode };
 
 export default async function AdminLayout({ children }: Props) {
   const supabase = getServerClient();
-
   const {
     data: { user },
   } = await supabase.auth.getUser();
@@ -21,7 +20,7 @@ export default async function AdminLayout({ children }: Props) {
     .eq('user_id', user.id)
     .maybeSingle<{ is_admin: boolean | null }>();
 
-  const isAdmin = profile?.is_admin === true;
+  const isAdmin = profile ? profile.is_admin === true : false;
   if (error || !isAdmin) redirect('/client');
 
   return (

--- a/app/(protected)/admin/pembayaran/page.tsx
+++ b/app/(protected)/admin/pembayaran/page.tsx
@@ -1,0 +1,12 @@
+export const dynamic = 'force-dynamic';
+
+import PaymentsTable from './table';
+
+export default function PaymentsPage() {
+  return (
+    <div className="bg-white rounded-xl border p-6">
+      <h1 className="text-xl font-semibold mb-4">Pembayaran</h1>
+      <PaymentsTable />
+    </div>
+  );
+}

--- a/app/(protected)/admin/pembayaran/table.tsx
+++ b/app/(protected)/admin/pembayaran/table.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export default function PaymentsTable() {
+  const { data, mutate } = useSWR('/api/admin/payments', fetcher);
+
+  const setStatus = async (id: string, status: 'paid' | 'unpaid') => {
+    await fetch(`/api/admin/payments/${id}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    mutate();
+  };
+
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr><th className="text-left">Invoice</th><th>Amount</th><th>Status</th><th>Aksi</th></tr>
+      </thead>
+      <tbody>
+        {data?.items?.map((p: any) => (
+          <tr key={p.id} className="border-t">
+            <td className="py-2">{p.invoice_no || '—'}</td>
+            <td>{Number(p.amount).toLocaleString()}</td>
+            <td>{p.status}</td>
+            <td>
+              {p.status === 'unpaid' ? (
+                <button
+                  className="px-2 py-1 rounded bg-emerald-600 text-white"
+                  onClick={() => setStatus(p.id, 'paid')}
+                >
+                  Tandai Lunas
+                </button>
+              ) : (
+                <button
+                  className="px-2 py-1 rounded bg-slate-200"
+                  onClick={() => setStatus(p.id, 'unpaid')}
+                >
+                  Set Unpaid
+                </button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/app/(protected)/admin/pengguna/page.tsx
+++ b/app/(protected)/admin/pengguna/page.tsx
@@ -1,0 +1,31 @@
+export const dynamic = 'force-dynamic';
+
+import { getServerClient } from '@/lib/supabaseServer';
+
+export default async function AdminUsers() {
+  const supabase = getServerClient();
+  const { data } = await supabase
+    .from('profiles')
+    .select('user_id, email, is_admin')
+    .order('created_at', { ascending: false })
+    .limit(200)
+    .returns<{ user_id: string; email: string | null; is_admin: boolean | null }[]>();
+
+  return (
+    <div className="bg-white rounded-xl border p-6">
+      <h1 className="text-xl font-semibold mb-4">Pengguna</h1>
+      <table className="w-full text-sm">
+        <thead><tr><th className="text-left">Email</th><th>Admin</th><th>User ID</th></tr></thead>
+        <tbody>
+          {data?.map((u) => (
+            <tr key={u.user_id} className="border-t">
+              <td className="py-2">{u.email}</td>
+              <td className="text-center">{u.is_admin ? '✅' : '—'}</td>
+              <td className="font-mono text-xs">{u.user_id}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/(protected)/admin/setting/page.tsx
+++ b/app/(protected)/admin/setting/page.tsx
@@ -1,0 +1,12 @@
+export const dynamic = 'force-dynamic';
+
+import SettingsForm from './settings-form';
+
+export default function SettingPage() {
+  return (
+    <div className="bg-white rounded-xl border p-6">
+      <h1 className="text-xl font-semibold mb-4">Setting</h1>
+      <SettingsForm />
+    </div>
+  );
+}

--- a/app/(protected)/admin/setting/settings-form.tsx
+++ b/app/(protected)/admin/setting/settings-form.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const DEFAULTS = {
+  trial_days: 7,
+  active_days: 365,
+  price: 250000,
+  payment_provider: { midtrans_enabled: false },
+  bank: { name: '', number: '', owner: '' },
+  contact: {
+    host_email: '',
+    smtp_email: '',
+    smtp_password: '',
+    wa_token: '',
+    wa_number: '',
+    wa_message: '',
+  },
+};
+
+export default function SettingsForm() {
+  const [value, setValue] = useState<any>(DEFAULTS);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/admin/settings')
+      .then((r) => r.json())
+      .then((j) => {
+        setValue({ ...DEFAULTS, ...(j?.value || {}) });
+        setLoading(false);
+      });
+  }, []);
+
+  const save = async () => {
+    await fetch('/api/admin/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ value }),
+    });
+    alert('Tersimpan');
+  };
+
+  if (loading) return <p>Memuat…</p>;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Field label="Trial (hari)">
+          <input
+            type="number"
+            className="border rounded px-2 py-1 w-full"
+            value={value.trial_days}
+            onChange={(e) => setValue({ ...value, trial_days: Number(e.target.value) })}
+          />
+        </Field>
+        <Field label="Masa Aktif (hari)">
+          <input
+            type="number"
+            className="border rounded px-2 py-1 w-full"
+            value={value.active_days}
+            onChange={(e) => setValue({ ...value, active_days: Number(e.target.value) })}
+          />
+        </Field>
+        <Field label="Harga (Rp)">
+          <input
+            type="number"
+            className="border rounded px-2 py-1 w-full"
+            value={value.price}
+            onChange={(e) => setValue({ ...value, price: Number(e.target.value) })}
+          />
+        </Field>
+      </div>
+
+      <div className="border rounded p-3">
+        <p className="font-medium mb-2">Payment</p>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={value.payment_provider.midtrans_enabled}
+            onChange={(e) =>
+              setValue({
+                ...value,
+                payment_provider: {
+                  ...value.payment_provider,
+                  midtrans_enabled: e.target.checked,
+                },
+              })
+            }
+          />
+          Midtrans enabled
+        </label>
+      </div>
+
+      <div className="border rounded p-3">
+        <p className="font-medium mb-2">Bank</p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <input
+            className="border rounded px-2 py-1"
+            placeholder="Nama Bank"
+            value={value.bank.name}
+            onChange={(e) => setValue({ ...value, bank: { ...value.bank, name: e.target.value } })}
+          />
+          <input
+            className="border rounded px-2 py-1"
+            placeholder="Nomor Rekening"
+            value={value.bank.number}
+            onChange={(e) => setValue({ ...value, bank: { ...value.bank, number: e.target.value } })}
+          />
+          <input
+            className="border rounded px-2 py-1"
+            placeholder="Nama Pemilik"
+            value={value.bank.owner}
+            onChange={(e) => setValue({ ...value, bank: { ...value.bank, owner: e.target.value } })}
+          />
+        </div>
+      </div>
+
+      <div className="border rounded p-3">
+        <p className="font-medium mb-2">Contact/Email/WA</p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <input
+            className="border rounded px-2 py-1"
+            placeholder="Host Email"
+            value={value.contact.host_email}
+            onChange={(e) => setValue({ ...value, contact: { ...value.contact, host_email: e.target.value } })}
+          />
+          <input
+            className="border rounded px-2 py-1"
+            placeholder="Email SMTP"
+            value={value.contact.smtp_email}
+            onChange={(e) => setValue({ ...value, contact: { ...value.contact, smtp_email: e.target.value } })}
+          />
+          <input
+            className="border rounded px-2 py-1"
+            placeholder="Password SMTP"
+            value={value.contact.smtp_password}
+            onChange={(e) => setValue({ ...value, contact: { ...value.contact, smtp_password: e.target.value } })}
+          />
+          <input
+            className="border rounded px-2 py-1"
+            placeholder="Token WA Gateway"
+            value={value.contact.wa_token}
+            onChange={(e) => setValue({ ...value, contact: { ...value.contact, wa_token: e.target.value } })}
+          />
+          <input
+            className="border rounded px-2 py-1"
+            placeholder="No Whatsapp"
+            value={value.contact.wa_number}
+            onChange={(e) => setValue({ ...value, contact: { ...value.contact, wa_number: e.target.value } })}
+          />
+          <input
+            className="border rounded px-2 py-1"
+            placeholder="Pesan Whatsapp"
+            value={value.contact.wa_message}
+            onChange={(e) => setValue({ ...value, contact: { ...value.contact, wa_message: e.target.value } })}
+          />
+        </div>
+      </div>
+
+      <button onClick={save} className="px-3 py-2 rounded bg-slate-900 text-white">Simpan</button>
+    </div>
+  );
+}
+
+function Field({ label, children }: any) {
+  return <label className="text-sm grid gap-1">{label}{children}</label>;
+}

--- a/app/(protected)/admin/thema/page.tsx
+++ b/app/(protected)/admin/thema/page.tsx
@@ -1,0 +1,14 @@
+export const dynamic = 'force-dynamic';
+
+import ThemeTable from './table';
+import ThemeUpload from './upload';
+
+export default function ThemesPage() {
+  return (
+    <div className="bg-white rounded-xl border p-6 space-y-6">
+      <h1 className="text-xl font-semibold">Tema</h1>
+      <ThemeUpload />
+      <ThemeTable />
+    </div>
+  );
+}

--- a/app/(protected)/admin/thema/table.tsx
+++ b/app/(protected)/admin/thema/table.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import useSWR from 'swr';
+
+const fetcher = (u: string) => fetch(u).then((r) => r.json());
+
+export default function ThemeTable() {
+  const { data, mutate } = useSWR('/api/admin/themes', fetcher);
+
+  const setStatus = async (id: string, status: 'active' | 'inactive') => {
+    await fetch(`/api/admin/themes/${id}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    mutate();
+  };
+
+  return (
+    <table className="w-full text-sm">
+      <thead><tr><th className="text-left">Nama</th><th>Slug</th><th>Status</th><th>Preview</th><th>Aksi</th></tr></thead>
+      <tbody>
+        {data?.items?.map((t: any) => (
+          <tr key={t.id} className="border-t">
+            <td className="py-2">{t.name}</td>
+            <td>{t.slug}</td>
+            <td>{t.status}</td>
+            <td>{t.preview_url ? <a className="text-blue-600" href={t.preview_url} target="_blank">lihat</a> : '—'}</td>
+            <td>
+              {t.status === 'inactive' ? (
+                <button
+                  className="px-2 py-1 rounded bg-emerald-600 text-white"
+                  onClick={() => setStatus(t.id, 'active')}
+                >
+                  Aktifkan
+                </button>
+              ) : (
+                <button
+                  className="px-2 py-1 rounded bg-slate-200"
+                  onClick={() => setStatus(t.id, 'inactive')}
+                >
+                  Nonaktifkan
+                </button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/app/(protected)/admin/thema/upload.tsx
+++ b/app/(protected)/admin/thema/upload.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function ThemeUpload() {
+  const [file, setFile] = useState<File | null>(null);
+  const [slug, setSlug] = useState('');
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file || !slug || !name) return;
+    setBusy(true);
+    const fd = new FormData();
+    fd.append('file', file);
+    fd.append('slug', slug);
+    fd.append('name', name);
+    const res = await fetch('/api/admin/themes', { method: 'POST', body: fd });
+    setBusy(false);
+    if (res.ok) {
+      setFile(null);
+      setSlug('');
+      setName('');
+      alert('Tema diunggah');
+      location.reload();
+    } else alert('Gagal upload tema');
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="flex gap-3 items-end">
+      <div><label className="block text-sm">Slug</label>
+        <input value={slug} onChange={(e) => setSlug(e.target.value)} className="border rounded px-2 py-1" /></div>
+      <div><label className="block text-sm">Nama</label>
+        <input value={name} onChange={(e) => setName(e.target.value)} className="border rounded px-2 py-1" /></div>
+      <div><label className="block text-sm">File (.zip)</label>
+        <input type="file" accept=".zip" onChange={(e) => setFile(e.target.files?.[0] ?? null)} /></div>
+      <button disabled={busy} className="px-3 py-2 bg-slate-900 text-white rounded">{busy ? 'Mengunggah…' : 'Upload Tema'}</button>
+    </form>
+  );
+}

--- a/app/(protected)/client/layout.tsx
+++ b/app/(protected)/client/layout.tsx
@@ -3,7 +3,6 @@ import { redirect } from 'next/navigation';
 
 import LogoutButton from '@/components/LogoutButton';
 import NavClient from '@/components/NavClient';
-import { getPublicSupabaseEnv } from '@/lib/publicEnv';
 import { getServerClient } from '@/lib/supabaseServer';
 
 type Props = { children: ReactNode };
@@ -19,19 +18,12 @@ export default async function ClientLayout({ children }: Props) {
       redirect('/login');
     }
 
-    const env = getPublicSupabaseEnv();
-
     return (
       <div className="min-h-screen bg-slate-50">
         <header className="border-b border-slate-200 bg-white/90 backdrop-blur">
           <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
             <NavClient />
-            <LogoutButton
-              supabaseUrl={env.url}
-              supabaseAnon={env.anon}
-              hasUrl={env.hasUrl}
-              hasAnon={env.hasAnon}
-            />
+            <LogoutButton />
           </div>
         </header>
         <main className="mx-auto max-w-6xl px-6 py-10">{children}</main>

--- a/app/api/admin/payments/[id]/status/route.ts
+++ b/app/api/admin/payments/[id]/status/route.ts
@@ -1,0 +1,13 @@
+import { requireAdmin } from '@/lib/adminGuard';
+export const dynamic = 'force-dynamic';
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const { admin } = await requireAdmin();
+  const body = await req.json();
+  const status = String(body?.status || '');
+  if (!['paid', 'unpaid'].includes(status)) return new Response('Invalid status', { status: 400 });
+
+  const { error } = await admin.from('payments').update({ status }).eq('id', params.id);
+  if (error) return new Response(error.message, { status: 400 });
+  return new Response(null, { status: 204 });
+}

--- a/app/api/admin/payments/route.ts
+++ b/app/api/admin/payments/route.ts
@@ -1,0 +1,12 @@
+import { requireAdmin } from '@/lib/adminGuard';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const { admin } = await requireAdmin();
+  const { data } = await admin
+    .from('payments')
+    .select('id, invoice_no, amount, status, created_at, user_id')
+    .order('created_at', { ascending: false })
+    .limit(200);
+  return Response.json({ items: data ?? [] });
+}

--- a/app/api/admin/settings/route.ts
+++ b/app/api/admin/settings/route.ts
@@ -1,0 +1,19 @@
+import { requireAdmin } from '@/lib/adminGuard';
+export const dynamic = 'force-dynamic';
+
+const KEY = 'global';
+
+export async function GET() {
+  const { admin } = await requireAdmin();
+  const { data } = await admin.from('settings').select('value').eq('key', KEY).maybeSingle();
+  return Response.json({ value: data?.value || null });
+}
+
+export async function PATCH(req: Request) {
+  const { admin } = await requireAdmin();
+  const body = await req.json();
+  const value = body?.value ?? {};
+  const { error } = await admin.from('settings').upsert({ key: KEY, value }, { onConflict: 'key' });
+  if (error) return new Response(error.message, { status: 400 });
+  return new Response(null, { status: 204 });
+}

--- a/app/api/admin/themes/[id]/status/route.ts
+++ b/app/api/admin/themes/[id]/status/route.ts
@@ -1,0 +1,13 @@
+import { requireAdmin } from '@/lib/adminGuard';
+export const dynamic = 'force-dynamic';
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const { admin } = await requireAdmin();
+  const body = await req.json();
+  const status = String(body?.status || '');
+  if (!['active', 'inactive'].includes(status)) return new Response('Invalid status', { status: 400 });
+
+  const { error } = await admin.from('themes').update({ status }).eq('id', params.id);
+  if (error) return new Response(error.message, { status: 400 });
+  return new Response(null, { status: 204 });
+}

--- a/app/api/admin/themes/route.ts
+++ b/app/api/admin/themes/route.ts
@@ -1,0 +1,45 @@
+import { requireAdmin } from '@/lib/adminGuard';
+import { NextRequest } from 'next/server';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const { admin } = await requireAdmin();
+  const { data } = await admin
+    .from('themes')
+    .select('id, slug, name, status, preview_url, package_path, created_at')
+    .order('created_at', { ascending: false });
+  return Response.json({ items: data ?? [] });
+}
+
+export async function POST(req: NextRequest) {
+  const { admin } = await requireAdmin();
+  const form = await req.formData();
+  const file = form.get('file') as File | null;
+  const slug = String(form.get('slug') || '');
+  const name = String(form.get('name') || '');
+  if (!file || !slug || !name) return new Response('Missing fields', { status: 400 });
+
+  const arrayBuffer = await file.arrayBuffer();
+  const bytes = new Uint8Array(arrayBuffer);
+  const ext = file.name.split('.').pop() || 'zip';
+  const objectPath = `${slug}/${Date.now()}.${ext}`;
+
+  const { data: put, error: upErr } = await admin.storage.from('themes').upload(objectPath, bytes, {
+    contentType: file.type || 'application/zip',
+    upsert: true,
+  });
+  if (upErr) return new Response(upErr.message, { status: 400 });
+
+  admin.storage.from('themes').getPublicUrl(objectPath);
+
+  const { error: insErr } = await admin.from('themes').insert({
+    slug,
+    name,
+    status: 'inactive',
+    preview_url: null,
+    package_path: put?.path ?? objectPath,
+  });
+  if (insErr) return new Response(insErr.message, { status: 400 });
+
+  return new Response(null, { status: 201 });
+}

--- a/components/AdminNav.js
+++ b/components/AdminNav.js
@@ -1,5 +1,0 @@
-import Link from 'next/link';
-export default function AdminNav(){
-  const items = [['/admin', 'Dashboard'], ['/admin/users', 'Pengguna'], ['/admin/payments', 'Pembayaran'], ['/admin/themes', 'Tema'], ['/admin/settings', 'Setting']];
-  return (<nav className="sticky top-0 bg-white/80 backdrop-blur z-20 border-b"><div className="container-narrow py-3 flex gap-3 flex-wrap">{items.map(([href, label]) => (<Link key={href} href={href} className="px-3 py-1.5 rounded-lg hover:bg-gray-100">{label}</Link>))}</div></nav>);
-}

--- a/components/AdminNav.tsx
+++ b/components/AdminNav.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import LogoutButton from './LogoutButton';
+
+const links = [
+  { href: '/admin', label: 'Dashboard' },
+  { href: '/admin/pengguna', label: 'Pengguna' },
+  { href: '/admin/pembayaran', label: 'Pembayaran' },
+  { href: '/admin/thema', label: 'Tema' },
+  { href: '/admin/setting', label: 'Setting' },
+];
+
+export default function AdminNav() {
+  const pathname = usePathname();
+  return (
+    <nav className="border-b bg-white">
+      <div className="mx-auto max-w-6xl px-6 h-14 flex items-center justify-between">
+        <div className="flex gap-4">
+          {links.map((l) => (
+            <Link
+              key={l.href}
+              href={l.href}
+              className={`text-sm px-2 py-1 rounded-md ${pathname === l.href ? 'bg-slate-100 font-semibold' : 'hover:bg-slate-50'}`}
+            >
+              {l.label}
+            </Link>
+          ))}
+        </div>
+        <LogoutButton />
+      </div>
+    </nav>
+  );
+}

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -1,60 +1,37 @@
 'use client';
 
-import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { createBrowserClient } from '@supabase/ssr';
+import { useState } from 'react';
 
-import { getBrowserClient } from '@/lib/supabaseClient';
+export default function LogoutButton() {
+  const r = useRouter();
+  const [loading, setLoading] = useState(false);
 
-type LogoutButtonProps = {
-  supabaseUrl: string;
-  supabaseAnon: string;
-  hasUrl: boolean;
-  hasAnon: boolean;
-};
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const supabaseAnon = (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY)!;
 
-export default function LogoutButton({ supabaseUrl, supabaseAnon, hasUrl, hasAnon }: LogoutButtonProps) {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
+  const onClick = async () => {
+    setLoading(true);
+    const supabase = createBrowserClient(supabaseUrl, supabaseAnon);
+    await supabase.auth.signOut();
 
-  const supabase = useMemo(() => {
-    if (!hasUrl || !hasAnon) {
-      return null;
-    }
+    await fetch('/auth/callback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event: 'SIGNED_OUT' }),
+    });
 
-    try {
-      return getBrowserClient(supabaseUrl, supabaseAnon);
-    } catch (error) {
-      console.error('Failed to init Supabase client', error);
-      return null;
-    }
-  }, [supabaseUrl, supabaseAnon, hasUrl, hasAnon]);
-
-  const isDisabled = isLoading || !supabase;
-
-  const handleLogout = async () => {
-    if (isDisabled) return;
-
-    setIsLoading(true);
-
-    try {
-      await supabase.auth.signOut();
-    } catch (error) {
-      console.error('Failed to sign out', error);
-    } finally {
-      router.replace('/login');
-      router.refresh();
-      setIsLoading(false);
-    }
+    r.replace('/login');
   };
 
   return (
     <button
-      type="button"
-      onClick={handleLogout}
-      disabled={isDisabled}
-      className="rounded-xl border border-[#0E356B] px-4 py-2 text-sm font-semibold text-[#0E356B] transition hover:bg-[#0E356B] hover:text-white disabled:cursor-not-allowed disabled:opacity-70"
+      onClick={onClick}
+      disabled={loading}
+      className="px-3 py-2 rounded-md text-sm font-medium bg-slate-100 hover:bg-slate-200"
     >
-      {isLoading ? 'Keluar...' : 'Logout'}
+      {loading ? 'Keluar…' : 'Logout'}
     </button>
   );
 }

--- a/components/NavAdmin.tsx
+++ b/components/NavAdmin.tsx
@@ -5,25 +5,18 @@ import { usePathname } from 'next/navigation';
 
 import LogoutButton from '@/components/LogoutButton';
 
-type NavAdminProps = {
-  supabaseUrl: string;
-  supabaseAnon: string;
-  hasUrl: boolean;
-  hasAnon: boolean;
-};
-
 const adminNavItems = [
   { href: '/admin', label: 'Dashboard' },
-  { href: '/admin/users', label: 'Pengguna' },
-  { href: '/admin/payments', label: 'Pembayaran' },
-  { href: '/admin/themes', label: 'Tema' },
-  { href: '/admin/settings', label: 'Setting' },
+  { href: '/admin/pengguna', label: 'Pengguna' },
+  { href: '/admin/pembayaran', label: 'Pembayaran' },
+  { href: '/admin/thema', label: 'Tema' },
+  { href: '/admin/setting', label: 'Setting' },
 ];
 
 const isActive = (currentPath: string, target: string) =>
   currentPath === target || currentPath.startsWith(`${target}/`);
 
-export default function NavAdmin({ supabaseUrl, supabaseAnon, hasUrl, hasAnon }: NavAdminProps) {
+export default function NavAdmin() {
   const pathname = usePathname();
 
   return (
@@ -42,12 +35,7 @@ export default function NavAdmin({ supabaseUrl, supabaseAnon, hasUrl, hasAnon }:
             </Link>
           ))}
         </nav>
-        <LogoutButton
-          supabaseUrl={supabaseUrl}
-          supabaseAnon={supabaseAnon}
-          hasUrl={hasUrl}
-          hasAnon={hasAnon}
-        />
+        <LogoutButton />
       </div>
     </header>
   );

--- a/lib/adminGuard.ts
+++ b/lib/adminGuard.ts
@@ -1,0 +1,39 @@
+import { cookies } from 'next/headers';
+import { createServerClient } from '@supabase/ssr';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+
+export async function requireAdmin() {
+  const cookieStore = cookies();
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anon = (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY)!;
+
+  const supabase = createServerClient(url, anon, {
+    cookies: {
+      get(name: string) {
+        return cookieStore.get(name)?.value;
+      },
+      set(name: string, value: string, options: any) {
+        cookieStore.set(name, value, options);
+      },
+      remove(name: string, options: any) {
+        cookieStore.set(name, '', { ...options, maxAge: 0 });
+      },
+    },
+  });
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('UNAUTHORIZED');
+
+  const { data: prof } = await supabase
+    .from('profiles')
+    .select('is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (!prof?.is_admin) throw new Error('FORBIDDEN');
+
+  const admin = getAdminClient();
+  return { admin, user } as const;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "next": "14.2.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-leaflet": "^4.2.1"
+        "react-leaflet": "^4.2.1",
+        "swr": "^2.3.6"
       },
       "devDependencies": {
         "@types/node": "^20.14.9",
@@ -1924,6 +1925,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/didyoumean": {
@@ -5499,6 +5509,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
+      "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -5926,6 +5949,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next": "14.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-leaflet": "^4.2.1"
+    "react-leaflet": "^4.2.1",
+    "swr": "^2.3.6"
   },
   "devDependencies": {
     "@types/node": "^20.14.9",

--- a/types/db.ts
+++ b/types/db.ts
@@ -90,17 +90,77 @@ export interface VisitLogUpdate {
 
 export interface PaymentRow {
   id: string;
-  status: string | null;
+  user_id: string;
+  amount: string;
+  status: 'unpaid' | 'paid';
+  invoice_no: string | null;
+  created_at: string | null;
 }
 
 export interface PaymentInsert {
   id?: string;
-  status?: string | null;
+  user_id: string;
+  amount?: string;
+  status?: 'unpaid' | 'paid';
+  invoice_no?: string | null;
+  created_at?: string | null;
 }
 
 export interface PaymentUpdate {
   id?: string;
-  status?: string | null;
+  user_id?: string;
+  amount?: string;
+  status?: 'unpaid' | 'paid';
+  invoice_no?: string | null;
+  created_at?: string | null;
+}
+
+export interface ThemeRow {
+  id: string;
+  slug: string;
+  name: string;
+  status: 'active' | 'inactive';
+  preview_url: string | null;
+  package_path: string | null;
+  created_at: string | null;
+}
+
+export interface ThemeInsert {
+  id?: string;
+  slug: string;
+  name: string;
+  status?: 'active' | 'inactive';
+  preview_url?: string | null;
+  package_path?: string | null;
+  created_at?: string | null;
+}
+
+export interface ThemeUpdate {
+  id?: string;
+  slug?: string;
+  name?: string;
+  status?: 'active' | 'inactive';
+  preview_url?: string | null;
+  package_path?: string | null;
+  created_at?: string | null;
+}
+
+export interface SettingRow {
+  key: string;
+  value: Record<string, unknown>;
+  updated_at: string | null;
+}
+
+export interface SettingInsert {
+  key: string;
+  value: Record<string, unknown>;
+  updated_at?: string | null;
+}
+
+export interface SettingUpdate {
+  key?: string;
+  value?: Record<string, unknown>;
+  updated_at?: string | null;
 }
 
 export type Database = {
@@ -134,6 +194,18 @@ export type Database = {
         Row: PaymentRow;
         Insert: PaymentInsert;
         Update: PaymentUpdate;
+        Relationships: [];
+      };
+      themes: {
+        Row: ThemeRow;
+        Insert: ThemeInsert;
+        Update: ThemeUpdate;
+        Relationships: [];
+      };
+      settings: {
+        Row: SettingRow;
+        Insert: SettingInsert;
+        Update: SettingUpdate;
         Relationships: [];
       };
     };


### PR DESCRIPTION
## Summary
- add reusable admin navigation with logout and enforce admin-only layout checks
- implement admin dashboard, user list, payment management, theme uploads, and settings pages with supporting client components
- create guarded admin API routes and Supabase schema updates for payments, themes, settings, plus typed definitions and SWR dependency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2083d3b9483249b21157a44854cb3