### PR TITLE
Fix admin bootstrap idempotency and profile upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,26 @@
 2) Jalankan: `npm install` lalu `npm run dev`.
 3) Di Supabase, buka **SQL Editor** dan jalankan `supabase/schema.sql` lalu `supabase/trigger_profiles.sql` (buat bucket Storage `media` public)
 
+### Bootstrap Admin
+
+1. Pastikan ENV di Vercel:
+   - `NEXT_PUBLIC_SUPABASE_URL`
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - `SUPABASE_SERVICE_ROLE_KEY` (server-only)
+   - `BOOTSTRAP_TOKEN` (server-only)
+
+2. Jalankan endpoint:
+```bash
+export BOOTSTRAP_TOKEN='isi_token_kamu'
+curl -iS -X POST 'https://<APP_DOMAIN>/api/admin-create-user' \
+  -H "x-bootstrap-token: $BOOTSTRAP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@gmail.com","password":"P@ssw0rd!","is_admin":true}'
+```
+
+(Jika profil belum muncul) jalankan supabase/sql/patch_profiles_admin.sql di Supabase SQL Editor.
+
+
 ### Kredensial Admin Supabase
 - Password **tidak** disimpan di tabel `profiles`. Supabase Auth menyimpan hash password secara terpisah di sistem autentikasinya.
 - Untuk membuat/ubah password admin, buka **Authentication → Users** di dashboard Supabase, pilih user yang diinginkan, lalu atur password atau kirim tautan reset.

--- a/app/api/admin-create-user/route.ts
+++ b/app/api/admin-create-user/route.ts
@@ -1,56 +1,69 @@
-// app/api/admin-create-user/route.ts
-import crypto from 'crypto';
+import type { NextRequest } from 'next/server';
 import { getAdminClient } from '@/lib/supabaseAdmin';
-export const dynamic = 'force-dynamic';
 
-function safeEq(a?: string | null, b?: string | null) {
-  const A = Buffer.from(a || '');
-  const B = Buffer.from(b || '');
-  if (A.length !== B.length) return false;
-  return crypto.timingSafeEqual(A, B);
+// Helper: cari userId dari email
+async function findUserIdByEmail(email: string) {
+  const admin = getAdminClient();
+  const { data, error } = await admin.auth.admin.listUsers({ page: 1, perPage: 1000 });
+  if (error) throw error;
+  return data.users.find(u => (u.email || '').toLowerCase() === email.toLowerCase())?.id ?? null;
 }
 
-export async function POST(req: Request) {
-  const provided = req.headers.get('x-bootstrap-token');
-  const secret = process.env.BOOTSTRAP_TOKEN;
-  if (!secret || !safeEq(provided, secret)) {
-    return new Response('Unauthorized', { status: 401 });
+export async function GET() {
+  return Response.json({
+    ok: true,
+    hasBootstrapToken: Boolean(process.env.BOOTSTRAP_TOKEN),
+    hasServiceRole: Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  // Token guard
+  const serverToken = process.env.BOOTSTRAP_TOKEN;
+  if (!serverToken) return new Response('BOOTSTRAP_TOKEN not set', { status: 500 });
+  const headerToken = req.headers.get('x-bootstrap-token');
+  if (!headerToken || headerToken !== serverToken) {
+    return new Response('Invalid or missing x-bootstrap-token', { status: 401 });
   }
 
-  try {
-    const body = await req.json();
-    const email: string = body?.email;
-    const password: string = body?.password;
-    const is_admin: boolean = !!body?.is_admin;
+  // Payload
+  let body: any;
+  try { body = await req.json(); } catch { return new Response('Invalid JSON body', { status: 400 }); }
+  const email = String(body?.email || '').trim();
+  const password = String(body?.password || '');
+  const is_admin = Boolean(body?.is_admin);
+  if (!email || !password) return new Response('Missing "email" or "password"', { status: 400 });
 
-    if (!email || !password) {
-      return new Response('Missing email or password', { status: 400 });
-    }
+  const admin = getAdminClient();
 
-    const admin = getAdminClient();
+  // 1) Coba create user
+  let userId: string | null = null;
+  const created = await admin.auth.admin.createUser({ email, password, email_confirm: true });
 
-    // 1) buat user & confirmed
-    const { data, error } = await admin.auth.admin.createUser({
-      email,
-      password,
-      email_confirm: true,
-    });
-    if (error) return new Response(error.message, { status: 400 });
+  if (created.error) {
+    const msg = created.error.message || '';
+    const already = /already|registered/i.test(msg);
+    if (!already) return new Response(`createUser error: ${msg}`, { status: 400 });
 
-    const user = data.user!;
-
-    // 2) upsert profiles TANPA kolom 'role'
-    const { error: upErr } = await admin
-      .from('profiles')
-      .upsert(
-        { user_id: user.id, email, is_admin }, // <— role dihapus
-        { onConflict: 'user_id' }
-      );
-
-    if (upErr) return new Response(upErr.message, { status: 400 });
-
-    return Response.json({ ok: true, user_id: user.id, email, is_admin }, { status: 201 });
-  } catch (e: any) {
-    return new Response(e?.message || 'Invalid payload', { status: 400 });
+    // Sudah ada → cari id, lalu sinkron password (opsional)
+    userId = await findUserIdByEmail(email);
+    if (!userId) return new Response('User exists but not found via listUsers', { status: 500 });
+    const upd = await admin.auth.admin.updateUserById(userId, { password });
+    if (upd.error) return new Response(`updateUserById error: ${upd.error.message}`, { status: 400 });
+  } else {
+    userId = created.data.user?.id ?? null;
   }
+
+  if (!userId) return new Response('No user id obtained', { status: 500 });
+
+  // 2) Upsert profile (kunci perbaikan!)
+  const up = await admin
+    .from('profiles')
+    .upsert({ user_id: userId, email, is_admin }, { onConflict: 'user_id' })
+    .select('user_id, email, is_admin')
+    .maybeSingle();
+
+  if (up.error) return new Response(`profiles upsert error: ${up.error.message}`, { status: 400 });
+
+  return Response.json({ ok: true, user_id: userId, profile: up.data }, { status: 200 });
 }

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,7 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
+
 export function getAdminClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !serviceKey) throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
-  return createClient(url, serviceKey, { auth: { autoRefreshToken: false, persistSession: false } });
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  if (!url || !key) {
+    throw new Error('Missing SUPABASE URL or SERVICE ROLE KEY');
+  }
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
 }

--- a/supabase/sql/patch_profiles_admin.sql
+++ b/supabase/sql/patch_profiles_admin.sql
@@ -1,0 +1,30 @@
+-- Pastikan kolom ada
+alter table public.profiles
+  add column if not exists is_admin boolean default false,
+  add column if not exists password_hash text;
+
+-- RLS baca profil sendiri (aman dijalankan berulang)
+do $$
+begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='profiles' and policyname='read own profile') then
+    create policy "read own profile" on public.profiles
+      for select to authenticated
+      using (user_id = auth.uid());
+  end if;
+end $$;
+
+-- Sinkronkan row profil untuk admin@gmail.com jika user Auth-nya sudah ada
+insert into public.profiles (user_id, email, full_name, is_admin)
+select u.id, u.email, 'Admin Supabase', true
+from auth.users u
+where lower(u.email) = lower('admin@gmail.com')
+on conflict (user_id) do update
+  set email = excluded.email,
+      full_name = excluded.full_name,
+      is_admin = true;
+
+-- Verifikasi
+select u.id as auth_id, u.email, p.is_admin
+from auth.users u
+left join public.profiles p on p.user_id = u.id
+where lower(u.email) = lower('admin@gmail.com');


### PR DESCRIPTION
## Summary
- add a Supabase service role helper for admin tasks
- rewrite the admin bootstrap endpoint to be idempotent and upsert profiles
- document and provide SQL patch to ensure admin profile columns are present

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2269333888324a162b6db12a08611