### PR TITLE
Fix Supabase invitation types and admin utilities

### DIFF
--- a/app/api/admin-create-user/route.ts
+++ b/app/api/admin-create-user/route.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from 'next/server';
+import type { User } from '@supabase/supabase-js';
 import { getAdminClient } from '@/lib/supabaseAdmin';
 
 // Helper: cari userId dari email
@@ -6,7 +7,10 @@ async function findUserIdByEmail(email: string) {
   const admin = getAdminClient();
   const { data, error } = await admin.auth.admin.listUsers({ page: 1, perPage: 1000 });
   if (error) throw error;
-  return data.users.find(u => (u.email || '').toLowerCase() === email.toLowerCase())?.id ?? null;
+  const users = (data?.users ?? []) as User[];
+  return (
+    users.find(user => (user.email ?? '').toLowerCase() === email.toLowerCase())?.id ?? null
+  );
 }
 
 export async function GET() {

--- a/app/api/onboarding/create-invitation/route.ts
+++ b/app/api/onboarding/create-invitation/route.ts
@@ -1,4 +1,6 @@
 import { getServerClient } from '@/lib/supabaseServer';
+import type { Database } from '@/types/db';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 export async function POST(req: Request) {
   const supabase = getServerClient();
@@ -18,7 +20,7 @@ export async function POST(req: Request) {
     .replace(/(^-|-$)/g, '');
   const slug = base || `undangan-${Date.now()}`;
 
-  const { error } = await supabase.from('invitations').insert({
+  const payload: Database['public']['Tables']['invitations']['Insert'] = {
     slug,
     title: `The Wedding of ${groom_name} & ${bride_name}`,
     groom_name,
@@ -38,7 +40,13 @@ export async function POST(req: Request) {
       prokes: false,
       gift: true,
     },
-  });
+  };
+
+  const typedSupabase = supabase as SupabaseClient<Database>;
+  const { error } = await typedSupabase
+    .from('invitations')
+    // Supabase client typing fails to infer our table schema, so cast is required.
+    .insert(payload as never);
 
   if (error) return new Response(error.message, { status: 400 });
 

--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -1,9 +1,10 @@
 import { cookies } from 'next/headers';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 import type { Database } from '@/types/db';
 
-export function getServerClient() {
+export function getServerClient(): SupabaseClient<Database> {
   const cookieStore = cookies();
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/types/db.ts
+++ b/types/db.ts
@@ -1,3 +1,11 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
 export interface ProfileRow {
   id: string;
   user_id: string;
@@ -33,26 +41,71 @@ export interface ProfileUpdate {
 
 export interface InvitationRow {
   id: string;
+  slug: string;
+  title: string | null;
+  groom_name: string;
+  bride_name: string;
+  groom_nickname: string | null;
+  bride_nickname: string | null;
+  groom_parents: string | null;
+  bride_parents: string | null;
+  date_display: string | null;
+  theme_slug: string | null;
+  cover_photo_url: string | null;
+  music_url: string | null;
   user_id: string | null;
+  custom_domain_suffix: string | null;
   view_count: number | null;
   is_published: boolean | null;
+  pages_enabled: Json | null;
   created_at: string | null;
+  updated_at: string | null;
 }
 
 export interface InvitationInsert {
   id?: string;
+  slug: string;
+  title?: string | null;
+  groom_name: string;
+  bride_name: string;
+  groom_nickname?: string | null;
+  bride_nickname?: string | null;
+  groom_parents?: string | null;
+  bride_parents?: string | null;
+  date_display?: string | null;
+  theme_slug?: string | null;
+  cover_photo_url?: string | null;
+  music_url?: string | null;
   user_id?: string | null;
+  custom_domain_suffix?: string | null;
   view_count?: number | null;
   is_published?: boolean | null;
+  pages_enabled?: Json | null;
   created_at?: string | null;
+  updated_at?: string | null;
 }
 
 export interface InvitationUpdate {
   id?: string;
+  slug?: string;
+  title?: string | null;
+  groom_name?: string;
+  bride_name?: string;
+  groom_nickname?: string | null;
+  bride_nickname?: string | null;
+  groom_parents?: string | null;
+  bride_parents?: string | null;
+  date_display?: string | null;
+  theme_slug?: string | null;
+  cover_photo_url?: string | null;
+  music_url?: string | null;
   user_id?: string | null;
+  custom_domain_suffix?: string | null;
   view_count?: number | null;
   is_published?: boolean | null;
+  pages_enabled?: Json | null;
   created_at?: string | null;
+  updated_at?: string | null;
 }
 
 export interface GuestRow {
@@ -147,19 +200,19 @@ export interface ThemeUpdate {
 
 export interface SettingRow {
   key: string;
-  value: Record<string, unknown>;
+  value: Json;
   updated_at: string | null;
 }
 
 export interface SettingInsert {
   key: string;
-  value: Record<string, unknown>;
+  value: Json;
   updated_at?: string | null;
 }
 
 export interface SettingUpdate {
   key?: string;
-  value?: Record<string, unknown>;
+  value?: Json;
   updated_at?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- align the generated Supabase invitation types with the schema and add a reusable Json helper
- type the server Supabase client and adjust the onboarding API to build a typed invitation payload
- harden the admin create-user helper by treating listed users as Supabase User objects

## Testing
- npm run build *(fails: missing NEXT_PUBLIC_SUPABASE_URL/NEXT_PUBLIC_SUPABASE_ANON_KEY in the environment and downstream supabaseUrl requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68e22e49c9f08324932e7430bd8fbd85