### PR TITLE
feat(auth): one-click login, email verification callback, and back buttons

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,9 +1,14 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { createClient } from '@supabase/supabase-js';
 
-import { supabaseBrowser } from '@/lib/supabaseBrowser';
+const sb = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
 
 export default function AdminLoginPage() {
   const [err, setErr] = useState<string | null>(null);
@@ -12,44 +17,60 @@ export default function AdminLoginPage() {
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (loading) return;
     setErr(null);
     setLoading(true);
+
     const fd = new FormData(e.currentTarget);
     const email = String(fd.get('email') || '');
     const password = String(fd.get('password') || '');
 
-    const { data, error } = await supabaseBrowser.auth.signInWithPassword({ email, password });
-    setLoading(false);
-    if (error) return setErr(error.message);
-
-    try {
-      await fetch('/auth/callback', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ event: 'SIGNED_IN', session: data.session }),
-      });
-    } catch (callbackError) {
-      console.error(callbackError);
-    }
-
-    const r = await fetch('/api/whoami', { cache: 'no-store' });
-    const { profile } = await r.json();
-
-    if (!profile?.is_admin) {
-      setErr('Akun ini bukan admin.');
+    const { error } = await sb.auth.signInWithPassword({ email, password });
+    if (error) {
+      setErr(error.message);
+      setLoading(false);
       return;
     }
-    router.replace('/admin/dashboard');
+
+    await sb.auth.getSession();
+
+    try {
+      const r = await fetch('/api/whoami', { cache: 'no-store' });
+      const { profile } = await r.json();
+      if (!profile?.is_admin) {
+        setErr('Akun ini bukan admin.');
+        setLoading(false);
+        return;
+      }
+    } catch (fetchError) {
+      console.error(fetchError);
+      setErr('Gagal memverifikasi akun admin.');
+      setLoading(false);
+      return;
+    }
+
+    router.refresh();
+    window.location.assign('/admin/dashboard');
   }
 
   return (
     <div className="min-h-screen grid place-items-center p-6">
       <form onSubmit={onSubmit} className="w-full max-w-md bg-white shadow rounded-xl p-6 space-y-4">
-        <h1 className="text-xl font-semibold">Login Admin</h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-xl font-semibold">Login Admin</h1>
+          <Link href="/" className="text-sm text-slate-600 hover:underline">
+            ← Kembali ke Beranda
+          </Link>
+        </div>
+
         <input name="email" type="email" required placeholder="Email" className="w-full border rounded px-3 py-2" />
         <input name="password" type="password" required placeholder="Password" className="w-full border rounded px-3 py-2" />
         {err && <p className="text-sm text-rose-600">{err}</p>}
-        <button disabled={loading} className="w-full py-2 rounded bg-blue-600 text-white">
+        <button
+          disabled={loading}
+          className="w-full py-2 rounded bg-blue-600 text-white disabled:opacity-60"
+          type="submit"
+        >
           {loading ? 'Masuk…' : 'Masuk'}
         </button>
       </form>

--- a/app/client/register/page.tsx
+++ b/app/client/register/page.tsx
@@ -21,24 +21,14 @@ export default function ClientRegister() {
     const groom = String(fd.get('groom_name') || '');
     const bride = String(fd.get('bride_name') || '');
 
-    const { data: sign, error: e1 } = await supabaseBrowser.auth.signUp({
+    const { error: e1 } = await supabaseBrowser.auth.signUp({
       email,
       password,
-      options: { emailRedirectTo: `${location.origin}/client/login` },
+      options: { emailRedirectTo: `${location.origin}/auth/callback` },
     });
     if (e1) {
       setLoading(false);
       return setErr(e1.message);
-    }
-
-    try {
-      await fetch('/auth/callback', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ event: 'SIGNED_IN', session: sign?.session }),
-      });
-    } catch (callbackError) {
-      console.error(callbackError);
     }
 
     try {

--- a/middleware.ts
+++ b/middleware.ts
@@ -26,10 +26,15 @@ export async function middleware(req: NextRequest) {
 
   const path = req.nextUrl.pathname;
 
+  const publicPaths = new Set(['/admin', '/admin/login', '/client/login', '/client/register', '/auth/callback']);
+  if (publicPaths.has(path)) {
+    return res;
+  }
+
   // ===== Admin rules =====
   // /admin  -> public (login page)
   // /admin/* (kecuali /admin & /admin/login) -> perlu user admin
-  if (path.startsWith('/admin') && path !== '/admin' && path !== '/admin/login') {
+  if (path.startsWith('/admin')) {
     if (!user) {
       return NextResponse.redirect(new URL('/admin', req.url));
     }
@@ -38,9 +43,7 @@ export async function middleware(req: NextRequest) {
   // ===== Client rules =====
   // /client/login & /client/register -> selalu boleh diakses (jangan auto-redirect)
   // /client (dashboard) & /client/* selain dua di atas -> butuh user
-  const isClientLogin = path === '/client/login';
-  const isClientRegister = path === '/client/register';
-  if (path.startsWith('/client') && !isClientLogin && !isClientRegister) {
+  if (path.startsWith('/client')) {
     if (path === '/client' || path.startsWith('/client/')) {
       if (!user) {
         return NextResponse.redirect(new URL('/client/login', req.url));


### PR DESCRIPTION
## Summary
- add an email verification callback route that exchanges Supabase codes and redirects to the client login with a success flag
- harden the client and admin login flows with one-click submission, back-to-home links, and hard navigations
- update registration redirects and middleware guard logic to honour the new callback and public auth paths

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e236391e748324977412c3a236b29d