### PR TITLE
Fix client login session handling with shared Supabase client

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,32 +1,73 @@
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import type { Session } from '@supabase/supabase-js';
+
+type AuthEvent = 'SIGNED_IN' | 'SIGNED_OUT' | 'TOKEN_REFRESHED';
+
+function createRouteClient() {
+  const cookieStore = cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (name: string) => cookieStore.get(name)?.value,
+        set: (name: string, value: string, options: CookieOptions) => {
+          cookieStore.set(name, value, options);
+        },
+        remove: (name: string, options: CookieOptions) => {
+          cookieStore.set(name, '', { ...options, maxAge: 0 });
+        },
+      },
+    }
+  );
+}
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const code = url.searchParams.get('code');
 
   if (code) {
-    const cookieStore = cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          get: (name: string) => cookieStore.get(name)?.value,
-          set: (name: string, value: string, options: CookieOptions) => {
-            cookieStore.set(name, value, options);
-          },
-          remove: (name: string, options: CookieOptions) => {
-            cookieStore.set(name, '', { ...options, maxAge: 0 });
-          },
-        },
-      }
-    );
-
+    const supabase = createRouteClient();
     await supabase.auth.exchangeCodeForSession(code);
   }
 
   const redirectTo = new URL('/client/login?verified=1', url.origin);
   return NextResponse.redirect(redirectTo);
+}
+
+type CallbackPayload = {
+  event?: AuthEvent;
+  session?: Session | null;
+};
+
+export async function POST(request: Request) {
+  let payload: CallbackPayload;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: 'Payload tidak valid.' }, { status: 400 });
+  }
+
+  const { event, session } = payload;
+  const supabase = createRouteClient();
+
+  if (event === 'SIGNED_OUT') {
+    await supabase.auth.signOut();
+    return NextResponse.json({ success: true });
+  }
+
+  if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+    if (!session) {
+      return NextResponse.json({ error: 'Session tidak ditemukan.' }, { status: 400 });
+    }
+
+    await supabase.auth.setSession(session);
+    return NextResponse.json({ success: true });
+  }
+
+  return NextResponse.json({ success: true });
 }

--- a/lib/supabaseBrowser.ts
+++ b/lib/supabaseBrowser.ts
@@ -1,8 +1,3 @@
-import { createClient } from '@supabase/supabase-js';
+import { getBrowserClient } from './supabaseClient';
 
-import type { Database } from '@/types/db';
-
-export const supabaseBrowser = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+export const supabaseBrowser = getBrowserClient();


### PR DESCRIPTION
## Summary
- reuse the cached browser Supabase client instead of creating a new instance per form
- sync Supabase auth cookies after client login by posting the session to /auth/callback
- add a POST handler for /auth/callback to set or clear sessions on the server

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2407bb88483248df6aef40eb88fb9