### PR TITLE
feat: client dashboard with CRUD panels

### DIFF
--- a/app/client/contact/page.tsx
+++ b/app/client/contact/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+
+import { sb } from '@/lib/supabaseBrowser';
+import { useActiveInvitation } from '@/lib/useActiveInvitation';
+
+export default function ContactPage() {
+  const { inv } = useActiveInvitation();
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [msg, setMsg] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setMsg(null);
+    const {
+      data: { user },
+    } = await sb.auth.getUser();
+    if (!user) {
+      setMsg('Harus login.');
+      return;
+    }
+    const { error } = await sb.from('contact_messages').insert({
+      user_id: user.id,
+      invitation_id: inv?.id || null,
+      subject,
+      body,
+    });
+    if (error) setMsg(error.message);
+    else {
+      setMsg('Pesan terkirim.');
+      setSubject('');
+      setBody('');
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="max-w-2xl space-y-3 rounded bg-white p-5 shadow">
+      <h1 className="text-xl font-semibold">Hubungi Kami</h1>
+      <input
+        className="w-full rounded border px-3 py-2"
+        placeholder="Subjek"
+        value={subject}
+        onChange={(e) => setSubject(e.target.value)}
+      />
+      <textarea
+        className="min-h-[140px] w-full rounded border px-3 py-2"
+        placeholder="Tulis pesan anda…"
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+      />
+      {msg && <p className="text-sm text-emerald-600">{msg}</p>}
+      <button className="rounded bg-slate-900 px-4 py-2 text-white">Kirim</button>
+    </form>
+  );
+}

--- a/app/client/guests/page.tsx
+++ b/app/client/guests/page.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { sb } from '@/lib/supabaseBrowser';
+import { useActiveInvitation } from '@/lib/useActiveInvitation';
+
+type GuestForm = {
+  name: string;
+  status: string;
+  message: string;
+  seats: number;
+};
+
+type GuestRow = {
+  id: string;
+  name: string;
+  status: string;
+  message: string | null;
+  seats: number | null;
+  created_at: string;
+};
+
+const defaultForm: GuestForm = { name: '', status: 'pending', message: '', seats: 1 };
+
+export default function GuestsPage() {
+  const { inv } = useActiveInvitation();
+  const [rows, setRows] = useState<GuestRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState<GuestForm>({ ...defaultForm });
+
+  async function load() {
+    if (!inv) return;
+    setLoading(true);
+    const { data } = await sb
+      .from('guests')
+      .select('id,name,status,message,seats,created_at')
+      .eq('invitation_id', inv.id)
+      .order('created_at', { ascending: false });
+    setRows((data as GuestRow[]) || []);
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inv?.id]);
+
+  async function addGuest(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!inv) return;
+    const { error } = await sb.from('guests').insert({ ...form, invitation_id: inv.id });
+    if (!error) {
+      setForm({ ...defaultForm });
+      load();
+    }
+  }
+
+  async function updateRow(id: string, patch: Partial<GuestRow>) {
+    await sb.from('guests').update(patch).eq('id', id);
+    load();
+  }
+
+  async function removeRow(id: string) {
+    await sb.from('guests').delete().eq('id', id);
+    load();
+  }
+
+  if (!inv) return <p>Memuat…</p>;
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Buku Tamu</h1>
+
+      <form onSubmit={addGuest} className="grid gap-3 rounded bg-white p-4 shadow md:grid-cols-4">
+        <input
+          required
+          placeholder="Nama Tamu"
+          className="rounded border px-3 py-2"
+          value={form.name}
+          onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+        />
+        <select
+          className="rounded border px-3 py-2"
+          value={form.status}
+          onChange={(e) => setForm((f) => ({ ...f, status: e.target.value }))}
+        >
+          <option value="pending">Pending</option>
+          <option value="yes">Hadir</option>
+          <option value="no">Tidak Hadir</option>
+        </select>
+        <input
+          placeholder="Ucapan"
+          className="col-span-1 rounded border px-3 py-2 md:col-span-2"
+          value={form.message}
+          onChange={(e) => setForm((f) => ({ ...f, message: e.target.value }))}
+        />
+        <input
+          type="number"
+          min={1}
+          className="rounded border px-3 py-2"
+          value={form.seats}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, seats: Number(e.target.value || 1) }))
+          }
+        />
+        <button className="rounded bg-slate-900 px-4 py-2 text-white">Simpan</button>
+      </form>
+
+      <div className="overflow-x-auto rounded bg-white shadow">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-100">
+            <tr>
+              <th className="p-2 text-left">Nama</th>
+              <th>Status</th>
+              <th>Ucapan</th>
+              <th>Kursi</th>
+              <th className="w-40">Aksi</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td className="p-3" colSpan={5}>
+                  Memuat…
+                </td>
+              </tr>
+            ) : rows.length ? (
+              rows.map((r) => (
+                <tr key={r.id} className="border-t">
+                  <td className="p-2">{r.name}</td>
+                  <td className="p-2">
+                    <select
+                      value={r.status}
+                      onChange={(e) => updateRow(r.id, { status: e.target.value })}
+                      className="rounded border px-2 py-1"
+                    >
+                      <option value="pending">Pending</option>
+                      <option value="yes">Hadir</option>
+                      <option value="no">Tidak Hadir</option>
+                    </select>
+                  </td>
+                  <td className="p-2">
+                    <input
+                      className="w-full rounded border px-2 py-1"
+                      defaultValue={r.message || ''}
+                      onBlur={(e) => updateRow(r.id, { message: e.target.value })}
+                    />
+                  </td>
+                  <td className="p-2">
+                    <input
+                      type="number"
+                      min={1}
+                      className="w-20 rounded border px-2 py-1"
+                      defaultValue={r.seats || 1}
+                      onBlur={(e) =>
+                        updateRow(r.id, { seats: Number(e.target.value || 1) })
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <button
+                      onClick={() => removeRow(r.id)}
+                      className="rounded bg-rose-600 px-3 py-1 text-white"
+                      type="button"
+                    >
+                      Hapus
+                    </button>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td className="p-3" colSpan={5}>
+                  Belum ada tamu.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/client/layout.tsx
+++ b/app/client/layout.tsx
@@ -1,0 +1,10 @@
+import ClientNav from '@/components/ClientNav';
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <ClientNav />
+      <main className="mx-auto max-w-6xl px-4 py-8">{children}</main>
+    </div>
+  );
+}

--- a/app/client/login/ClientLoginForm.tsx
+++ b/app/client/login/ClientLoginForm.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import type { Session } from '@supabase/supabase-js';
 
-import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { sb } from '@/lib/supabaseBrowser';
 
 export default function ClientLoginForm() {
   const [err, setErr] = useState<string | null>(null);
@@ -25,7 +25,7 @@ export default function ClientLoginForm() {
     const email = String(fd.get('email') || '');
     const password = String(fd.get('password') || '');
 
-    const { data, error } = await supabaseBrowser.auth.signInWithPassword({ email, password });
+    const { data, error } = await sb.auth.signInWithPassword({ email, password });
     if (error || !data.session) {
       setErr(error?.message ?? 'Gagal masuk.');
       setLoading(false);

--- a/app/client/page.tsx
+++ b/app/client/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import { sb } from '@/lib/supabaseBrowser';
+import { useActiveInvitation } from '@/lib/useActiveInvitation';
+
+export default function ClientHome() {
+  const { loading, inv } = useActiveInvitation();
+  const [stats, setStats] = useState({ visits: 0, guests: 0, testimonials: 0 });
+
+  useEffect(() => {
+    (async () => {
+      if (!inv) return;
+      const [{ count: v }, { count: g }, { count: t }] = await Promise.all([
+        sb.from('visit_logs').select('id', { count: 'exact', head: true }).eq('invitation_id', inv.id),
+        sb.from('guests').select('id', { count: 'exact', head: true }).eq('invitation_id', inv.id),
+        sb.from('testimonials').select('id', { count: 'exact', head: true }).eq('invitation_id', inv.id),
+      ]);
+      setStats({ visits: v || 0, guests: g || 0, testimonials: t || 0 });
+    })();
+  }, [inv]);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Beranda</h1>
+      {loading ? (
+        <p>Memuat…</p>
+      ) : inv ? (
+        <>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <Card title="Undangan Aktif" value={inv.slug} href="/client/settings" />
+            <Card title="Total Kunjungan" value={stats.visits} href="/client/visitors" />
+            <Card title="Ucapan" value={stats.testimonials} href="/client/testimonials" />
+          </div>
+        </>
+      ) : (
+        <p>Belum ada undangan. Buat dari menu Registrasi.</p>
+      )}
+    </div>
+  );
+}
+
+function Card({ title, value, href }: { title: string; value: any; href: string }) {
+  return (
+    <Link
+      href={href}
+      className="block rounded-xl bg-white p-5 shadow transition hover:shadow-md"
+    >
+      <div className="text-sm opacity-70">{title}</div>
+      <div className="mt-1 text-2xl font-semibold">{String(value)}</div>
+    </Link>
+  );
+}

--- a/app/client/register/page.tsx
+++ b/app/client/register/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { sb } from '@/lib/supabaseBrowser';
 
 export default function ClientRegister() {
   const [err, setErr] = useState<string | null>(null);
@@ -21,7 +21,7 @@ export default function ClientRegister() {
     const groom = String(fd.get('groom_name') || '');
     const bride = String(fd.get('bride_name') || '');
 
-    const { error: e1 } = await supabaseBrowser.auth.signUp({
+    const { error: e1 } = await sb.auth.signUp({
       email,
       password,
       options: { emailRedirectTo: `${location.origin}/auth/callback` },

--- a/app/client/settings/page.tsx
+++ b/app/client/settings/page.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { sb } from '@/lib/supabaseBrowser';
+import { useActiveInvitation } from '@/lib/useActiveInvitation';
+
+type FormState = {
+  slug: string;
+  title: string;
+  groom_name: string;
+  bride_name: string;
+  theme_slug: string;
+  cover_photo_url: string;
+  music_url: string;
+  custom_domain_suffix: string;
+  is_published: boolean;
+};
+
+export default function SettingsPage() {
+  const { inv, setInv } = useActiveInvitation();
+  const [form, setForm] = useState<FormState | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!inv) return;
+    setForm({
+      slug: inv.slug || '',
+      title: inv.title || '',
+      groom_name: inv.groom_name || '',
+      bride_name: inv.bride_name || '',
+      theme_slug: inv.theme_slug || 'jawabiru',
+      cover_photo_url: inv.cover_photo_url || '',
+      music_url: inv.music_url || '',
+      custom_domain_suffix: inv.custom_domain_suffix || '',
+      is_published: !!inv.is_published,
+    });
+  }, [inv]);
+
+  async function onSave(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!inv || !form) return;
+    setSaving(true);
+    setMsg(null);
+
+    const { error, data } = await sb
+      .from('invitations')
+      .update({
+        ...form,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', inv.id)
+      .select('*')
+      .maybeSingle();
+
+    setSaving(false);
+
+    if (error) {
+      setMsg(error.message);
+      return;
+    }
+
+    setMsg('Tersimpan.');
+    if (data) {
+      setInv(data);
+    }
+  }
+
+  function set<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
+  }
+
+  if (!inv || !form) return <p>Memuat…</p>;
+
+  return (
+    <form onSubmit={onSave} className="grid max-w-3xl gap-4">
+      <h1 className="text-xl font-semibold">Pengaturan Website</h1>
+
+      <Field label="Slug" value={form.slug} onChange={(v) => set('slug', v)} />
+      <Field label="Judul" value={form.title} onChange={(v) => set('title', v)} />
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field
+          label="Nama Mempelai Pria"
+          value={form.groom_name}
+          onChange={(v) => set('groom_name', v)}
+        />
+        <Field
+          label="Nama Mempelai Wanita"
+          value={form.bride_name}
+          onChange={(v) => set('bride_name', v)}
+        />
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field label="Tema" value={form.theme_slug} onChange={(v) => set('theme_slug', v)} />
+        <Field label="Musik (URL)" value={form.music_url} onChange={(v) => set('music_url', v)} />
+      </div>
+      <Field
+        label="Cover Photo URL"
+        value={form.cover_photo_url}
+        onChange={(v) => set('cover_photo_url', v)}
+      />
+      <Field
+        label="Domain Kustom (suffix)"
+        value={form.custom_domain_suffix}
+        onChange={(v) => set('custom_domain_suffix', v)}
+      />
+
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={!!form.is_published}
+          onChange={(e) => set('is_published', e.target.checked)}
+        />
+        <span>Publikasikan undangan</span>
+      </label>
+
+      {msg && <p className="text-sm text-emerald-600">{msg}</p>}
+      <div className="flex gap-3">
+        <button disabled={saving} className="rounded bg-slate-900 px-4 py-2 text-white">
+          {saving ? 'Menyimpan…' : 'Simpan'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="block">
+      <div className="mb-1 text-sm">{label}</div>
+      <input
+        className="w-full rounded border bg-white px-3 py-2"
+        value={value ?? ''}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </label>
+  );
+}

--- a/app/client/testimonials/page.tsx
+++ b/app/client/testimonials/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { sb } from '@/lib/supabaseBrowser';
+import { useActiveInvitation } from '@/lib/useActiveInvitation';
+
+type TestimonialForm = {
+  author: string;
+  body: string;
+  rating: number;
+};
+
+type TestimonialRow = {
+  id: string;
+  author: string;
+  body: string | null;
+  rating: number | null;
+  created_at: string;
+};
+
+const defaultForm: TestimonialForm = { author: '', body: '', rating: 5 };
+
+export default function TestimonialsPage() {
+  const { inv } = useActiveInvitation();
+  const [rows, setRows] = useState<TestimonialRow[]>([]);
+  const [form, setForm] = useState<TestimonialForm>({ ...defaultForm });
+
+  async function load() {
+    if (!inv) return;
+    const { data } = await sb
+      .from('testimonials')
+      .select('id,author,body,rating,created_at')
+      .eq('invitation_id', inv.id)
+      .order('created_at', { ascending: false });
+    setRows((data as TestimonialRow[]) || []);
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inv?.id]);
+
+  async function add(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!inv) return;
+    await sb.from('testimonials').insert({ ...form, invitation_id: inv.id });
+    setForm({ ...defaultForm });
+    load();
+  }
+
+  async function updateRow(id: string, patch: Partial<TestimonialRow>) {
+    await sb.from('testimonials').update(patch).eq('id', id);
+    load();
+  }
+
+  async function removeRow(id: string) {
+    await sb.from('testimonials').delete().eq('id', id);
+    load();
+  }
+
+  if (!inv) return <p>Memuat…</p>;
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Testimoni</h1>
+
+      <form onSubmit={add} className="grid gap-3 rounded bg-white p-4 shadow md:grid-cols-4">
+        <input
+          required
+          placeholder="Nama"
+          className="rounded border px-3 py-2"
+          value={form.author}
+          onChange={(e) => setForm((f) => ({ ...f, author: e.target.value }))}
+        />
+        <select
+          className="rounded border px-3 py-2"
+          value={form.rating}
+          onChange={(e) => setForm((f) => ({ ...f, rating: Number(e.target.value) }))}
+        >
+          {[1, 2, 3, 4, 5].map((n) => (
+            <option key={n} value={n}>
+              {n} ⭐
+            </option>
+          ))}
+        </select>
+        <input
+          placeholder="Ucapan"
+          className="col-span-2 rounded border px-3 py-2"
+          value={form.body}
+          onChange={(e) => setForm((f) => ({ ...f, body: e.target.value }))}
+        />
+        <button className="rounded bg-slate-900 px-4 py-2 text-white">Simpan</button>
+      </form>
+
+      <div className="overflow-x-auto rounded bg-white shadow">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-100">
+            <tr>
+              <th className="p-2 text-left">Nama</th>
+              <th>Rating</th>
+              <th>Ucapan</th>
+              <th className="w-40">Aksi</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-t">
+                <td className="p-2">{r.author}</td>
+                <td className="p-2">
+                  <select
+                    defaultValue={r.rating ?? 5}
+                    onChange={(e) => updateRow(r.id, { rating: Number(e.target.value) })}
+                    className="rounded border px-2 py-1"
+                  >
+                    {[1, 2, 3, 4, 5].map((n) => (
+                      <option key={n} value={n}>
+                        {n} ⭐
+                      </option>
+                    ))}
+                  </select>
+                </td>
+                <td className="p-2">
+                  <input
+                    defaultValue={r.body || ''}
+                    onBlur={(e) => updateRow(r.id, { body: e.target.value })}
+                    className="w-full rounded border px-2 py-1"
+                  />
+                </td>
+                <td className="p-2">
+                  <button
+                    onClick={() => removeRow(r.id)}
+                    className="rounded bg-rose-600 px-3 py-1 text-white"
+                    type="button"
+                  >
+                    Hapus
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/client/visitors/page.tsx
+++ b/app/client/visitors/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { sb } from '@/lib/supabaseBrowser';
+import { useActiveInvitation } from '@/lib/useActiveInvitation';
+
+type VisitRow = {
+  id: string;
+  created_at: string;
+  ip: string | null;
+  ua: string | null;
+};
+
+export default function VisitorsPage() {
+  const { inv } = useActiveInvitation();
+  const [rows, setRows] = useState<VisitRow[]>([]);
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [count, setCount] = useState(0);
+
+  async function load() {
+    if (!inv) return;
+    let query = sb
+      .from('visit_logs')
+      .select('id,created_at,ip,ua', { count: 'exact' })
+      .eq('invitation_id', inv.id)
+      .order('created_at', { ascending: false })
+      .limit(200);
+    if (from) query = query.gte('created_at', from);
+    if (to) query = query.lte('created_at', to);
+    const { data, count } = await query;
+    setRows((data as VisitRow[]) || []);
+    setCount(count || 0);
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inv?.id]);
+
+  if (!inv) return <p>Memuat…</p>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Riwayat Pengunjung</h1>
+
+      <div className="flex flex-wrap gap-3 rounded bg-white p-4 shadow">
+        <label className="text-sm">
+          Dari:
+          <input
+            type="datetime-local"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+            className="ml-2 rounded border px-2 py-1"
+          />
+        </label>
+        <label className="text-sm">
+          Sampai:
+          <input
+            type="datetime-local"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            className="ml-2 rounded border px-2 py-1"
+          />
+        </label>
+        <button onClick={load} className="rounded bg-slate-900 px-4 py-2 text-white">
+          Terapkan
+        </button>
+        <div className="ml-auto text-sm">
+          Total: <b>{count}</b>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded bg-white shadow">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-100">
+            <tr>
+              <th className="p-2 text-left">Waktu</th>
+              <th>IP</th>
+              <th>User Agent</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-t">
+                <td className="p-2">{new Date(r.created_at).toLocaleString()}</td>
+                <td className="p-2">{r.ip || '-'}</td>
+                <td className="p-2">{r.ua?.slice(0, 120) || '-'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/components/ClientNav.tsx
+++ b/components/ClientNav.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const items = [
+  { href: '/client', label: 'Dashboard' },
+  { href: '/client/settings', label: 'Pengaturan Website' },
+  { href: '/client/guests', label: 'Buku Tamu' },
+  { href: '/client/visitors', label: 'Riwayat Pengunjung' },
+  { href: '/client/testimonials', label: 'Testimoni' },
+  { href: '/client/contact', label: 'Hubungi Kami' },
+];
+
+export default function ClientNav() {
+  const p = usePathname();
+
+  if (p === '/client/login' || p === '/client/register') {
+    return null;
+  }
+
+  return (
+    <nav className="border-b bg-white">
+      <div className="mx-auto max-w-6xl px-4">
+        <ul className="flex flex-wrap gap-4 py-3 text-sm">
+          {items.map((it) => (
+            <li key={it.href}>
+              <Link
+                href={it.href}
+                className={`px-3 py-1.5 rounded ${
+                  p === it.href ? 'bg-slate-900 text-white' : 'hover:bg-slate-100'
+                }`}
+              >
+                {it.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -3,7 +3,7 @@
 import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 
-import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { sb } from '@/lib/supabaseBrowser';
 
 export default function LogoutButton() {
   const router = useRouter();
@@ -12,7 +12,7 @@ export default function LogoutButton() {
 
   const onClick = async () => {
     setLoading(true);
-    await supabaseBrowser.auth.signOut();
+    await sb.auth.signOut();
 
     try {
       await fetch('/auth/callback', {

--- a/lib/supabaseBrowser.ts
+++ b/lib/supabaseBrowser.ts
@@ -1,3 +1,10 @@
-import { getBrowserClient } from './supabaseClient';
+import { createClient } from '@supabase/supabase-js';
 
-export const supabaseBrowser = getBrowserClient();
+import type { Database } from '@/types/db';
+
+export const sb = createClient<Database>(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
+
+export const supabaseBrowser = sb;

--- a/lib/useActiveInvitation.ts
+++ b/lib/useActiveInvitation.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import type { Database } from '@/types/db';
+
+import { sb } from './supabaseBrowser';
+
+type Invitation = Database['public']['Tables']['invitations']['Row'];
+
+export function useActiveInvitation() {
+  const [loading, setLoading] = useState(true);
+  const [inv, setInv] = useState<Invitation | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      setLoading(true);
+      const {
+        data: { user },
+      } = await sb.auth.getUser();
+      if (!user) {
+        if (!alive) return;
+        setError('not-auth');
+        setInv(null);
+        setLoading(false);
+        return;
+      }
+
+      const { data, error } = await sb
+        .from('invitations')
+        .select('*')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (!alive) return;
+      if (error) {
+        setError(error.message);
+      } else {
+        setError(null);
+      }
+      setInv(data ?? null);
+      setLoading(false);
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return { loading, inv, error, setInv } as const;
+}


### PR DESCRIPTION
## Summary
- introduce a shared client dashboard layout and navigation
- wire up a reusable Supabase browser client hook for the active invitation
- implement dashboard, settings, guests, visitors, testimonials, and contact management pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2467e72f88324902c290c154a7300