### PR TITLE
feat: add client gallery media management

### DIFF
--- a/app/api/blob/callback/route.ts
+++ b/app/api/blob/callback/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { handleUpload } from '@vercel/blob';
+import { createClient } from '@supabase/supabase-js';
+
+import type { Database } from '@/types/db';
+
+export const runtime = 'edge';
+
+type UploadMetadata = {
+  invitation_id?: string;
+  media_type?: 'photo' | 'video';
+  owner_user_id?: string;
+  original_name?: string;
+};
+
+const admin = () =>
+  createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    {
+      auth: { autoRefreshToken: false, persistSession: false },
+    }
+  );
+
+export async function POST(req: NextRequest) {
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) {
+    return new NextResponse('Blob token missing', { status: 500 });
+  }
+
+  let completedPayload: { blob?: { url: string }; tokenPayload?: string | null } | null = null;
+  let metadata: UploadMetadata | null = null;
+
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body) {
+    return new NextResponse('Invalid callback', { status: 400 });
+  }
+
+  await handleUpload({
+    token,
+    request: req,
+    body,
+    onBeforeGenerateToken: async () => ({}),
+    onUploadCompleted: async (payload) => {
+      completedPayload = payload;
+      if (payload.tokenPayload) {
+        try {
+          metadata = JSON.parse(payload.tokenPayload) as UploadMetadata;
+        } catch (error) {
+          console.error('[blob/callback] failed to parse tokenPayload', error);
+        }
+      }
+        if (!metadata && body && typeof body === 'object' && 'metadata' in body) {
+          const raw = (body as { metadata?: UploadMetadata }).metadata;
+          if (raw) {
+            metadata = raw;
+          }
+        }
+    },
+  }).catch((error) => {
+    console.error('[blob/callback] handleUpload failed', error);
+  });
+
+  // payload should be assigned in onUploadCompleted
+  const payload = completedPayload;
+  if (!payload?.blob || !metadata?.invitation_id || !metadata.media_type || !metadata.owner_user_id) {
+    return new NextResponse('Invalid callback payload', { status: 400 });
+  }
+
+  const supa = admin();
+  const { data: owns } = await supa
+    .from('invitations')
+    .select('id')
+    .eq('id', metadata.invitation_id)
+    .eq('user_id', metadata.owner_user_id)
+    .maybeSingle();
+
+  if (!owns) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+
+  const { error } = await supa.from('media').insert({
+    invitation_id: metadata.invitation_id,
+    type: metadata.media_type,
+    url: payload.blob.url,
+    caption: metadata.original_name,
+    sort_index: 0,
+  });
+
+  if (error) {
+    console.error('[blob/callback] insert failed', error);
+    return new NextResponse(error.message, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true, url: payload.blob.url });
+}

--- a/app/api/blob/delete/route.ts
+++ b/app/api/blob/delete/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { del } from '@vercel/blob';
+
+import { getServerClient } from '@/lib/supabaseServer';
+
+export const runtime = 'edge';
+
+export async function POST(req: NextRequest) {
+  const { media_id } = (await req.json().catch(() => ({}))) as { media_id?: string };
+  if (!media_id) {
+    return new NextResponse('Missing media_id', { status: 400 });
+  }
+
+  const supabase = getServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const { data: row } = await supabase
+    .from('media')
+    .select('id, url, invitation_id, invitations!inner(user_id)')
+    .eq('id', media_id)
+    .maybeSingle();
+
+  const ownerId = (row as unknown as { invitations?: { user_id?: string } } | null)?.invitations?.user_id;
+  if (!row || ownerId !== user.id) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+
+  try {
+    await del(row.url, { token: process.env.BLOB_READ_WRITE_TOKEN });
+  } catch (error) {
+    console.warn('[blob/delete] failed to delete blob', error);
+  }
+
+  await supabase.from('media').delete().eq('id', media_id);
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/blob/upload-url/route.ts
+++ b/app/api/blob/upload-url/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getServerClient } from '@/lib/supabaseServer';
+
+export const runtime = 'edge';
+
+type CreateUploadUrlOptions = {
+  access: 'public' | 'private';
+  token: string;
+  contentType?: string;
+  metadata?: Record<string, string>;
+  callbackUrl?: string;
+};
+
+async function createUploadUrl({ access, token, contentType, metadata, callbackUrl }: CreateUploadUrlOptions) {
+  if (!token) {
+    throw new Error('Missing blob token');
+  }
+
+  const baseUrl = process.env.VERCEL_BLOB_API_URL ?? 'https://blob.vercel-storage.com';
+  const endpoint = `${baseUrl.replace(/\/$/, '')}/upload-url`;
+  const payload: Record<string, unknown> = { access };
+  if (contentType) payload.contentType = contentType;
+  if (metadata) payload.metadata = metadata;
+  if (callbackUrl) payload.callbackUrl = callbackUrl;
+
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${token}`,
+      'x-api-version': '6',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || 'Failed to create upload URL');
+  }
+
+  const json = (await res.json()) as { uploadUrl?: string };
+  if (!json.uploadUrl) {
+    throw new Error('Upload URL missing in response');
+  }
+  return json.uploadUrl;
+}
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const invitationId = url.searchParams.get('invitation_id');
+  const type = url.searchParams.get('type');
+  const filename = url.searchParams.get('filename') || 'upload.bin';
+  const contentType = url.searchParams.get('contentType') || undefined;
+
+  if (!invitationId || !type) {
+    return new NextResponse('Missing params', { status: 400 });
+  }
+  if (!['photo', 'video'].includes(type)) {
+    return new NextResponse('Invalid type', { status: 400 });
+  }
+
+  const supabase = getServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const { data: owns } = await supabase
+    .from('invitations')
+    .select('id')
+    .eq('id', invitationId)
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (!owns) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+
+  const blobToken = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!blobToken) {
+    return new NextResponse('Blob token missing', { status: 500 });
+  }
+
+  try {
+    const uploadUrl = await createUploadUrl({
+      access: 'public',
+      token: blobToken,
+      contentType,
+      metadata: {
+        invitation_id: invitationId,
+        media_type: type,
+        owner_user_id: user.id,
+        original_name: filename,
+      },
+      callbackUrl: `${url.origin}/api/blob/callback`,
+    });
+
+    return NextResponse.json({ url: uploadUrl });
+  } catch (error) {
+    console.error('[blob/upload-url]', error);
+    return new NextResponse('Failed to create upload URL', { status: 500 });
+  }
+}

--- a/app/client/gallery/page.tsx
+++ b/app/client/gallery/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { sb } from '@/lib/supabaseBrowser';
+import { useActiveInvitation } from '@/lib/useActiveInvitation';
+
+type Row = {
+  id: string;
+  type: 'photo' | 'video';
+  url: string;
+  caption: string | null;
+  created_at: string;
+};
+
+export default function GalleryPage() {
+  const { inv } = useActiveInvitation();
+  const [rows, setRows] = useState<Row[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [progressText, setProgressText] = useState<string | null>(null);
+
+  async function load() {
+    if (!inv) return;
+    const { data } = await sb
+      .from('media')
+      .select('id,type,url,caption,created_at')
+      .eq('invitation_id', inv.id)
+      .order('created_at', { ascending: false });
+    setRows((data as Row[]) || []);
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inv?.id]);
+
+  async function onPickFiles(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files;
+    if (!files || !inv) return;
+    setBusy(true);
+    setProgressText('Menyiapkan unggahan…');
+
+    for (const file of Array.from(files)) {
+      const type: 'photo' | 'video' = file.type.startsWith('video/') ? 'video' : 'photo';
+      const params = new URLSearchParams({
+        invitation_id: inv.id,
+        type,
+        filename: file.name,
+        contentType: file.type,
+      });
+
+      const res = await fetch(`/api/blob/upload-url?${params.toString()}`);
+      if (!res.ok) {
+        console.warn('Gagal membuat upload URL', await res.text());
+        continue;
+      }
+      const { url } = (await res.json()) as { url: string };
+      setProgressText(`Mengunggah ${file.name}…`);
+
+      const up = await fetch(url, { method: 'POST', body: file });
+      if (!up.ok) {
+        console.warn('Upload gagal:', file.name, up.statusText);
+      }
+    }
+
+    setProgressText(null);
+    setBusy(false);
+    await load();
+    e.currentTarget.value = '';
+  }
+
+  async function remove(id: string) {
+    const ok = window.confirm('Hapus media ini?');
+    if (!ok) return;
+    await fetch('/api/blob/delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ media_id: id }),
+    });
+    load();
+  }
+
+  if (!inv) {
+    return <p>Memuat…</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Gallery / Album</h1>
+        <label className="inline-flex items-center gap-2 rounded bg-slate-900 px-4 py-2 text-white">
+          <input
+            type="file"
+            accept="image/*,video/*"
+            multiple
+            className="hidden"
+            onChange={onPickFiles}
+            disabled={busy}
+          />
+          {busy ? 'Mengunggah…' : 'Upload Foto/Video'}
+        </label>
+      </div>
+      {progressText && <p className="text-sm text-slate-600">{progressText}</p>}
+
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        {rows.map((r) => (
+          <div key={r.id} className="overflow-hidden rounded bg-white shadow">
+            {r.type === 'photo' ? (
+              <img src={r.url} alt={r.caption || ''} className="h-40 w-full object-cover" />
+            ) : (
+              <video src={r.url} controls className="h-40 w-full object-cover" />
+            )}
+            <div className="flex items-center justify-between p-3 text-sm">
+              <span className="truncate">{r.caption || r.type}</span>
+              <button
+                type="button"
+                onClick={() => remove(r.id)}
+                className="rounded bg-rose-600 px-2 py-1 text-white"
+              >
+                Hapus
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/client/register/page.tsx
+++ b/app/client/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { sb } from '@/lib/supabaseBrowser';
@@ -48,7 +49,12 @@ export default function ClientRegister() {
   return (
     <div className="min-h-screen grid place-items-center p-6">
       <form onSubmit={onSubmit} className="w-full max-w-lg space-y-4 rounded-xl bg-white p-6 shadow">
-        <h1 className="text-xl font-semibold">Daftar Akun</h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-xl font-semibold">Daftar Akun</h1>
+          <Link href="/" className="text-sm text-slate-600 hover:underline">
+            ← Kembali ke Beranda
+          </Link>
+        </div>
         <input name="full_name" required placeholder="Nama Lengkap" className="w-full rounded border px-3 py-2" />
         <input name="email" type="email" required placeholder="Email" className="w-full rounded border px-3 py-2" />
         <input name="password" type="password" required placeholder="Password" className="w-full rounded border px-3 py-2" />

--- a/components/ClientNav.tsx
+++ b/components/ClientNav.tsx
@@ -9,6 +9,7 @@ const items = [
   { href: '/client/guests', label: 'Buku Tamu' },
   { href: '/client/visitors', label: 'Riwayat Pengunjung' },
   { href: '/client/testimonials', label: 'Testimoni' },
+  { href: '/client/gallery', label: 'Gallery' },
   { href: '/client/contact', label: 'Hubungi Kami' },
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.45.0",
+        "@vercel/blob": "^0.18.0",
         "leaflet": "^1.9.4",
         "next": "14.2.5",
         "react": "18.2.0",
@@ -137,6 +138,15 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1102,6 +1112,20 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/blob": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-0.18.0.tgz",
+      "integrity": "sha512-DKjzhGfvBIzYjAI8RLsoEWB8NYUkMXL3TQLeKO5V1qLglgckuetwtfnYPF0OeTLezklE9m//vMpBS0qkxP4RRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "1.3.3",
+        "bytes": "3.1.2",
+        "undici": "5.28.2"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1400,6 +1424,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1571,6 +1604,15 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/call-bind": {
@@ -4844,6 +4886,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5867,6 +5918,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.45.0",
+    "@vercel/blob": "^0.18.0",
     "leaflet": "^1.9.4",
     "next": "14.2.5",
     "react": "18.2.0",

--- a/types/db.ts
+++ b/types/db.ts
@@ -108,6 +108,36 @@ export interface InvitationUpdate {
   updated_at?: string | null;
 }
 
+export interface MediaRow {
+  id: string;
+  invitation_id: string | null;
+  type: 'photo' | 'music' | 'video';
+  url: string;
+  caption: string | null;
+  sort_index: number | null;
+  created_at: string | null;
+}
+
+export interface MediaInsert {
+  id?: string;
+  invitation_id?: string | null;
+  type: 'photo' | 'music' | 'video';
+  url: string;
+  caption?: string | null;
+  sort_index?: number | null;
+  created_at?: string | null;
+}
+
+export interface MediaUpdate {
+  id?: string;
+  invitation_id?: string | null;
+  type?: 'photo' | 'music' | 'video';
+  url?: string;
+  caption?: string | null;
+  sort_index?: number | null;
+  created_at?: string | null;
+}
+
 export interface GuestRow {
   id: string;
   invitation_id: string | null;
@@ -229,6 +259,12 @@ export type Database = {
         Row: InvitationRow;
         Insert: InvitationInsert;
         Update: InvitationUpdate;
+        Relationships: [];
+      };
+      media: {
+        Row: MediaRow;
+        Insert: MediaInsert;
+        Update: MediaUpdate;
         Relationships: [];
       };
       guests: {


### PR DESCRIPTION
## Summary
- add Supabase media typings and API routes for Vercel Blob uploads, callback handling, and deletion
- build client gallery page with multi-file upload flow, progress feedback, and delete actions
- expose gallery navigation link and add back button on client registration page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e24a0290fc83249aca6eefdb921926