### PR TITLE
Fix client dashboard routes and add admin branding logo upload

### DIFF
--- a/app/(protected)/admin/setting/settings-form.tsx
+++ b/app/(protected)/admin/setting/settings-form.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from 'react';
 
+import { LogoUploader } from '@/components/LogoUploader';
+
 const DEFAULTS = {
   trial_days: 7,
   active_days: 365,
@@ -44,6 +46,7 @@ export default function SettingsForm() {
 
   return (
     <div className="space-y-4">
+      <LogoUploader />
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <Field label="Trial (hari)">
           <input

--- a/app/(protected)/client/page.tsx
+++ b/app/(protected)/client/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 import { getServerClient } from '@/lib/supabaseServer';
@@ -61,16 +62,19 @@ export default async function ClientDashboardPage() {
         title: 'Undangan Aktif',
         value: activeInvitationsDisplay,
         description: 'Jumlah undangan yang terhubung dengan akun Anda.',
+        href: '/client/settings',
       },
       {
         title: 'Total Kunjungan',
         value: totalVisitsDisplay,
         description: 'Akumulasi kunjungan dari semua undangan aktif.',
+        href: '/client/visitors',
       },
       {
         title: 'Ucapan',
         value: totalMessagesDisplay,
         description: 'Jumlah ucapan dan RSVP yang diterima tamu.',
+        href: '/client/testimonials',
       },
     ];
 
@@ -85,11 +89,15 @@ export default async function ClientDashboardPage() {
 
         <div className="grid gap-6 md:grid-cols-3">
           {cards.map((card) => (
-            <div key={card.title} className="rounded-2xl bg-white p-6 shadow-xl">
+            <Link
+              key={card.title}
+              href={card.href}
+              className="block rounded-2xl bg-white p-6 shadow-xl transition hover:shadow-2xl"
+            >
               <p className="text-sm font-medium text-gray-500">{card.title}</p>
               <p className="mt-4 text-3xl font-semibold text-gray-900">{card.value}</p>
               <p className="mt-2 text-xs text-gray-500">{card.description}</p>
-            </div>
+            </Link>
           ))}
         </div>
       </section>

--- a/app/api/admin/branding/route.ts
+++ b/app/api/admin/branding/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+
+import { getServerClient } from '@/lib/supabaseServer';
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const logoUrl = body?.logo_url as string | undefined;
+  if (!logoUrl) {
+    return new NextResponse('logo_url required', { status: 400 });
+  }
+
+  const supabase = getServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('is_admin, role')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    return new NextResponse(profileError.message, { status: 400 });
+  }
+
+  const isAdmin = !!profile && (profile.is_admin === true || profile.role === 'admin');
+  if (!isAdmin) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+
+  const { error } = await supabase
+    .from('settings')
+    .upsert({ key: 'branding', value: { logo_url: logoUrl } }, { onConflict: 'key' });
+
+  if (error) {
+    return new NextResponse(error.message, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/blob/upload-url/route.ts
+++ b/app/api/blob/upload-url/route.ts
@@ -68,15 +68,28 @@ export async function GET(req: NextRequest) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
 
-  const { data: owns } = await supabase
-    .from('invitations')
-    .select('id')
-    .eq('id', invitationId)
-    .eq('user_id', user.id)
-    .maybeSingle();
+  if (invitationId === 'brand') {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('is_admin, role')
+      .eq('user_id', user.id)
+      .maybeSingle();
 
-  if (!owns) {
-    return new NextResponse('Forbidden', { status: 403 });
+    const isAdmin = !!profile && (profile.is_admin === true || profile.role === 'admin');
+    if (!isAdmin) {
+      return new NextResponse('Forbidden', { status: 403 });
+    }
+  } else {
+    const { data: owns } = await supabase
+      .from('invitations')
+      .select('id')
+      .eq('id', invitationId)
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (!owns) {
+      return new NextResponse('Forbidden', { status: 403 });
+    }
   }
 
   const blobToken = process.env.BLOB_READ_WRITE_TOKEN;

--- a/app/client/guests/page.tsx
+++ b/app/client/guests/page.tsx
@@ -24,7 +24,7 @@ type GuestRow = {
 const defaultForm: GuestForm = { name: '', status: 'pending', message: '', seats: 1 };
 
 export default function GuestsPage() {
-  const { inv } = useActiveInvitation();
+  const { inv, loading: invitationLoading } = useActiveInvitation();
   const [rows, setRows] = useState<GuestRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [form, setForm] = useState<GuestForm>({ ...defaultForm });
@@ -42,6 +42,11 @@ export default function GuestsPage() {
   }
 
   useEffect(() => {
+    if (!inv) {
+      setRows([]);
+      setLoading(false);
+      return;
+    }
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inv?.id]);
@@ -66,7 +71,8 @@ export default function GuestsPage() {
     load();
   }
 
-  if (!inv) return <p>Memuat…</p>;
+  if (invitationLoading) return <p>Memuat…</p>;
+  if (!inv) return <p>Belum ada undangan. Silakan buat undangan terlebih dahulu.</p>;
 
   return (
     <div className="space-y-6">
@@ -100,9 +106,7 @@ export default function GuestsPage() {
           min={1}
           className="rounded border px-3 py-2"
           value={form.seats}
-          onChange={(e) =>
-            setForm((f) => ({ ...f, seats: Number(e.target.value || 1) }))
-          }
+          onChange={(e) => setForm((f) => ({ ...f, seats: Number(e.target.value || 1) }))}
         />
         <button className="rounded bg-slate-900 px-4 py-2 text-white">Simpan</button>
       </form>
@@ -153,9 +157,7 @@ export default function GuestsPage() {
                       min={1}
                       className="w-20 rounded border px-2 py-1"
                       defaultValue={r.seats || 1}
-                      onBlur={(e) =>
-                        updateRow(r.id, { seats: Number(e.target.value || 1) })
-                      }
+                      onBlur={(e) => updateRow(r.id, { seats: Number(e.target.value || 1) })}
                     />
                   </td>
                   <td className="p-2">

--- a/app/client/metrics/page.tsx
+++ b/app/client/metrics/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/client/visitors');
+}

--- a/app/client/settings/page.tsx
+++ b/app/client/settings/page.tsx
@@ -18,13 +18,16 @@ type FormState = {
 };
 
 export default function SettingsPage() {
-  const { inv, setInv } = useActiveInvitation();
+  const { inv, setInv, loading } = useActiveInvitation();
   const [form, setForm] = useState<FormState | null>(null);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!inv) return;
+    if (!inv) {
+      setForm(null);
+      return;
+    }
     setForm({
       slug: inv.slug || '',
       title: inv.title || '',
@@ -71,7 +74,9 @@ export default function SettingsPage() {
     setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
   }
 
-  if (!inv || !form) return <p>Memuat…</p>;
+  if (loading) return <p>Memuat…</p>;
+  if (!inv) return <p>Belum ada undangan. Silakan buat undangan terlebih dahulu.</p>;
+  if (!form) return <p>Memuat…</p>;
 
   return (
     <form onSubmit={onSave} className="grid max-w-3xl gap-4">
@@ -80,26 +85,14 @@ export default function SettingsPage() {
       <Field label="Slug" value={form.slug} onChange={(v) => set('slug', v)} />
       <Field label="Judul" value={form.title} onChange={(v) => set('title', v)} />
       <div className="grid gap-4 md:grid-cols-2">
-        <Field
-          label="Nama Mempelai Pria"
-          value={form.groom_name}
-          onChange={(v) => set('groom_name', v)}
-        />
-        <Field
-          label="Nama Mempelai Wanita"
-          value={form.bride_name}
-          onChange={(v) => set('bride_name', v)}
-        />
+        <Field label="Nama Mempelai Pria" value={form.groom_name} onChange={(v) => set('groom_name', v)} />
+        <Field label="Nama Mempelai Wanita" value={form.bride_name} onChange={(v) => set('bride_name', v)} />
       </div>
       <div className="grid gap-4 md:grid-cols-2">
         <Field label="Tema" value={form.theme_slug} onChange={(v) => set('theme_slug', v)} />
         <Field label="Musik (URL)" value={form.music_url} onChange={(v) => set('music_url', v)} />
       </div>
-      <Field
-        label="Cover Photo URL"
-        value={form.cover_photo_url}
-        onChange={(v) => set('cover_photo_url', v)}
-      />
+      <Field label="Cover Photo URL" value={form.cover_photo_url} onChange={(v) => set('cover_photo_url', v)} />
       <Field
         label="Domain Kustom (suffix)"
         value={form.custom_domain_suffix}

--- a/app/client/support/page.tsx
+++ b/app/client/support/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/client/contact');
+}

--- a/app/client/visitors/page.tsx
+++ b/app/client/visitors/page.tsx
@@ -13,33 +13,45 @@ type VisitRow = {
 };
 
 export default function VisitorsPage() {
-  const { inv } = useActiveInvitation();
+  const { inv, loading: invitationLoading } = useActiveInvitation();
   const [rows, setRows] = useState<VisitRow[]>([]);
   const [from, setFrom] = useState('');
   const [to, setTo] = useState('');
   const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(false);
 
   async function load() {
     if (!inv) return;
-    let query = sb
-      .from('visit_logs')
-      .select('id,created_at,ip,ua', { count: 'exact' })
-      .eq('invitation_id', inv.id)
-      .order('created_at', { ascending: false })
-      .limit(200);
-    if (from) query = query.gte('created_at', from);
-    if (to) query = query.lte('created_at', to);
-    const { data, count } = await query;
-    setRows((data as VisitRow[]) || []);
-    setCount(count || 0);
+    setLoading(true);
+    try {
+      let query = sb
+        .from('visit_logs')
+        .select('id,created_at,ip,ua', { count: 'exact' })
+        .eq('invitation_id', inv.id)
+        .order('created_at', { ascending: false })
+        .limit(200);
+      if (from) query = query.gte('created_at', from);
+      if (to) query = query.lte('created_at', to);
+      const { data, count } = await query;
+      setRows((data as VisitRow[]) || []);
+      setCount(count || 0);
+    } finally {
+      setLoading(false);
+    }
   }
 
   useEffect(() => {
+    if (!inv) {
+      setRows([]);
+      setCount(0);
+      return;
+    }
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inv?.id]);
 
-  if (!inv) return <p>Memuat…</p>;
+  if (invitationLoading) return <p>Memuat…</p>;
+  if (!inv) return <p>Belum ada undangan. Silakan buat undangan terlebih dahulu.</p>;
 
   return (
     <div className="space-y-4">
@@ -64,8 +76,8 @@ export default function VisitorsPage() {
             className="ml-2 rounded border px-2 py-1"
           />
         </label>
-        <button onClick={load} className="rounded bg-slate-900 px-4 py-2 text-white">
-          Terapkan
+        <button onClick={load} className="rounded bg-slate-900 px-4 py-2 text-white" disabled={loading}>
+          {loading ? 'Memuat…' : 'Terapkan'}
         </button>
         <div className="ml-auto text-sm">
           Total: <b>{count}</b>
@@ -82,13 +94,21 @@ export default function VisitorsPage() {
             </tr>
           </thead>
           <tbody>
-            {rows.map((r) => (
-              <tr key={r.id} className="border-t">
-                <td className="p-2">{new Date(r.created_at).toLocaleString()}</td>
-                <td className="p-2">{r.ip || '-'}</td>
-                <td className="p-2">{r.ua?.slice(0, 120) || '-'}</td>
+            {rows.length ? (
+              rows.map((r) => (
+                <tr key={r.id} className="border-t">
+                  <td className="p-2">{new Date(r.created_at).toLocaleString()}</td>
+                  <td className="p-2">{r.ip || '-'}</td>
+                  <td className="p-2">{r.ua?.slice(0, 120) || '-'}</td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td className="p-3" colSpan={3}>
+                  {loading ? 'Memuat…' : 'Belum ada kunjungan.'}
+                </td>
               </tr>
-            ))}
+            )}
           </tbody>
         </table>
       </div>

--- a/app/client/website/page.tsx
+++ b/app/client/website/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../settings/page';

--- a/app/page.js
+++ b/app/page.js
@@ -1,5 +1,7 @@
 import Link from 'next/link';
 
+import Brand from '@/components/Brand';
+
 const stats = [
   { value: '25+', label: 'Tema Premium Siap Pakai' },
   { value: '120K+', label: 'RSVP & Ucapan Masuk' },
@@ -111,9 +113,7 @@ export default function Home() {
     <main className="bg-slate-50 text-slate-900">
       <header className="sticky top-0 z-30 border-b border-slate-200/70 bg-white/85 backdrop-blur">
         <div className="container-wide flex items-center justify-between py-3">
-          <Link href="/" className="font-bold text-xl text-brand">
-            JadiUndangan
-          </Link>
+          <Brand />
           <nav className="hidden items-center gap-6 text-sm font-medium md:flex">
             <a href="#beranda" className="hover:text-brand">Beranda</a>
             <a href="#fitur" className="hover:text-brand">Fitur</a>

--- a/components/Brand.tsx
+++ b/components/Brand.tsx
@@ -1,0 +1,31 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { getServerClient } from '@/lib/supabaseServer';
+
+export default async function Brand() {
+  let logo: string | null = null;
+
+  try {
+    const supabase = getServerClient();
+    const { data } = await supabase
+      .from('settings')
+      .select('value')
+      .eq('key', 'branding')
+      .maybeSingle();
+
+    logo = (data?.value as { logo_url?: string } | null)?.logo_url ?? null;
+  } catch (error) {
+    logo = null;
+  }
+
+  return (
+    <Link href="/" className="flex items-center gap-2">
+      {logo ? (
+        <Image src={logo} alt="Logo" width={28} height={28} className="rounded" />
+      ) : (
+        <span className="font-bold text-xl text-brand">JadiUndangan</span>
+      )}
+    </Link>
+  );
+}

--- a/components/LogoUploader.tsx
+++ b/components/LogoUploader.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState, type ChangeEvent } from 'react';
+
+export function LogoUploader() {
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onPick(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setBusy(true);
+    setMessage(null);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams({
+        type: 'photo',
+        filename: file.name,
+        contentType: file.type || 'image/png',
+        invitation_id: 'brand',
+      });
+      const uploadUrlRes = await fetch(`/api/blob/upload-url?${params.toString()}`);
+      if (!uploadUrlRes.ok) {
+        throw new Error('Tidak dapat membuat upload URL');
+      }
+      const { url } = (await uploadUrlRes.json()) as { url?: string };
+      if (!url) throw new Error('Upload URL kosong');
+
+      const blobRes = await fetch(url, {
+        method: 'POST',
+        headers: file.type ? { 'content-type': file.type } : undefined,
+        body: file,
+      });
+      if (!blobRes.ok) {
+        throw new Error('Upload gagal');
+      }
+      let blobUrl = '';
+      try {
+        const json = await blobRes.json();
+        blobUrl = json?.url ?? '';
+      } catch {
+        blobUrl = blobRes.headers.get('location') ?? '';
+      }
+      if (!blobUrl) {
+        throw new Error('URL logo tidak tersedia');
+      }
+
+      const brandingRes = await fetch('/api/admin/branding', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ logo_url: blobUrl }),
+      });
+
+      if (!brandingRes.ok) {
+        const text = await brandingRes.text();
+        throw new Error(text || 'Gagal menyimpan logo');
+      }
+
+      setMessage('Logo diperbarui.');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Terjadi kesalahan';
+      setError(msg);
+    } finally {
+      setBusy(false);
+      e.target.value = '';
+    }
+  }
+
+  return (
+    <div className="space-y-2 rounded border bg-white p-4 shadow">
+      <div>
+        <h2 className="text-sm font-semibold text-slate-900">Logo Brand</h2>
+        <p className="text-xs text-slate-500">Unggah logo baru untuk mengganti branding publik.</p>
+      </div>
+      <input type="file" accept="image/*" onChange={onPick} disabled={busy} />
+      {busy && <p className="text-xs text-slate-500">Mengunggah…</p>}
+      {message && <p className="text-xs text-emerald-600">{message}</p>}
+      {error && <p className="text-xs text-rose-600">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- fix stale client dashboard links and provide redirects for legacy routes
- harden active invitation hook and client pages to stop endless loading when no invitation is present
- add admin branding logo upload API/UI and render configurable brand logo on public navbar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e31e0341988324957fbf074bb384d7