### PR TITLE
Fix admin branding route type checks

### DIFF
--- a/app/api/admin/branding/route.ts
+++ b/app/api/admin/branding/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { getServerClient } from '@/lib/supabaseServer';
+import type { Database, Profile } from '@/types/db';
 
 export async function POST(req: Request) {
   const body = await req.json().catch(() => ({}));
@@ -17,11 +18,13 @@ export async function POST(req: Request) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
 
+  type ProfileRoleInfo = Pick<Profile, 'is_admin' | 'role'>;
+
   const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('is_admin, role')
     .eq('user_id', user.id)
-    .maybeSingle();
+    .maybeSingle<ProfileRoleInfo>();
 
   if (profileError) {
     return new NextResponse(profileError.message, { status: 400 });
@@ -32,9 +35,14 @@ export async function POST(req: Request) {
     return new NextResponse('Forbidden', { status: 403 });
   }
 
+  type BrandingSetting = Database['public']['Tables']['settings']['Insert'];
+
+  const brandingSettings: BrandingSetting = { key: 'branding', value: { logo_url: logoUrl } };
+
   const { error } = await supabase
     .from('settings')
-    .upsert({ key: 'branding', value: { logo_url: logoUrl } }, { onConflict: 'key' });
+    // Supabase's generated types currently widen this table to `never`, so cast until the schema typings are updated.
+    .upsert(brandingSettings as never, { onConflict: 'key' });
 
   if (error) {
     return new NextResponse(error.message, { status: 400 });

--- a/app/api/blob/upload-url/route.ts
+++ b/app/api/blob/upload-url/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getServerClient } from '@/lib/supabaseServer';
+import type { Profile } from '@/types/db';
 
 export const runtime = 'edge';
 
@@ -69,11 +70,13 @@ export async function GET(req: NextRequest) {
   }
 
   if (invitationId === 'brand') {
+    type ProfileRoleInfo = Pick<Profile, 'is_admin' | 'role'>;
+
     const { data: profile } = await supabase
       .from('profiles')
       .select('is_admin, role')
       .eq('user_id', user.id)
-      .maybeSingle();
+      .maybeSingle<ProfileRoleInfo>();
 
     const isAdmin = !!profile && (profile.is_admin === true || profile.role === 'admin');
     if (!isAdmin) {

--- a/components/Brand.tsx
+++ b/components/Brand.tsx
@@ -2,19 +2,23 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { getServerClient } from '@/lib/supabaseServer';
+import type { Database } from '@/types/db';
 
 export default async function Brand() {
   let logo: string | null = null;
 
   try {
     const supabase = getServerClient();
+    type BrandingSetting = Database['public']['Tables']['settings']['Row'];
+
     const { data } = await supabase
       .from('settings')
       .select('value')
       .eq('key', 'branding')
-      .maybeSingle();
+      .maybeSingle<BrandingSetting>();
 
-    logo = (data?.value as { logo_url?: string } | null)?.logo_url ?? null;
+    const brandingValue = (data?.value as { logo_url?: string | null } | null) ?? null;
+    logo = typeof brandingValue?.logo_url === 'string' ? brandingValue.logo_url : null;
   } catch (error) {
     logo = null;
   }


### PR DESCRIPTION
## Summary
- add explicit Supabase profile typing for admin-only endpoints to satisfy type checking
- type branding settings interactions to avoid runtime null errors and clarify Supabase casts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e32782f59c832492beea10cc51830b