### PR TITLE
feat: add client registration flow with invitation creation

### DIFF
--- a/app/api/public/register/route.ts
+++ b/app/api/public/register/route.ts
@@ -1,0 +1,171 @@
+import { NextResponse } from 'next/server';
+
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+type Payload = {
+  account: { email: string; password: string; full_name?: string };
+  invitation: {
+    slug?: string;
+    title?: string;
+    groom_name: string;
+    bride_name: string;
+    theme_slug: string;
+    date_display?: string;
+    location?: string;
+  };
+  options?: { confirmEmail?: boolean };
+};
+
+const slugify = (s: string) =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '')
+    .slice(0, 60);
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as Payload;
+
+  const email = body?.account?.email?.trim();
+  const password = body?.account?.password;
+  const full_name = body?.account?.full_name?.trim() || null;
+  const inv = body?.invitation;
+
+  if (!email || !password || !inv?.groom_name || !inv?.bride_name || !inv?.theme_slug) {
+    return new NextResponse('Missing required fields', { status: 400 });
+  }
+
+  const { data: theme, error: themeErr } = await supabaseAdmin
+    .from('themes')
+    .select('slug,status')
+    .eq('slug', inv.theme_slug)
+    .eq('status', 'active')
+    .maybeSingle();
+
+  if (themeErr) {
+    return new NextResponse(themeErr.message, { status: 400 });
+  }
+
+  if (!theme) {
+    return new NextResponse('Theme not available', { status: 400 });
+  }
+
+  const baseSlug = inv.slug?.trim() || slugify(`${inv.groom_name}-${inv.bride_name}`);
+
+  if (!baseSlug) {
+    return new NextResponse('Slug is required', { status: 400 });
+  }
+
+  const { data: exists, error: slugErr } = await supabaseAdmin
+    .from('invitations')
+    .select('id')
+    .eq('slug', baseSlug)
+    .maybeSingle();
+
+  if (slugErr) {
+    return new NextResponse(slugErr.message, { status: 400 });
+  }
+
+  if (exists) {
+    return new NextResponse('Slug already taken', { status: 409 });
+  }
+
+  const confirmEmail = body?.options?.confirmEmail ?? true;
+  const { data: createdUser, error: createErr } = await supabaseAdmin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: !confirmEmail,
+    user_metadata: { full_name },
+  });
+
+  if (createErr || !createdUser?.user?.id) {
+    return new NextResponse(createErr?.message || 'Create user failed', { status: 400 });
+  }
+
+  const user_id = createdUser.user.id;
+
+  const { error: profileErr } = await supabaseAdmin.from('profiles').upsert(
+    {
+      user_id,
+      email,
+      full_name,
+      is_admin: false,
+    },
+    { onConflict: 'user_id' }
+  );
+
+  if (profileErr) {
+    return new NextResponse(profileErr.message, { status: 400 });
+  }
+
+  const now = new Date().toISOString();
+  const { data: invRow, error: invErr } = await supabaseAdmin
+    .from('invitations')
+    .insert({
+      user_id,
+      slug: baseSlug,
+      title: inv.title || `The Wedding of ${inv.groom_name} & ${inv.bride_name}`,
+      groom_name: inv.groom_name,
+      bride_name: inv.bride_name,
+      theme_slug: theme.slug,
+      date_display: inv.date_display || null,
+      music_url: null,
+      cover_photo_url: null,
+      pages_enabled: {
+        cover: true,
+        couple: true,
+        event: true,
+        wishes: true,
+        gallery: true,
+        story: true,
+        location: true,
+        qrcode: true,
+        prokes: false,
+        gift: true,
+      },
+      is_published: false,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('id')
+    .maybeSingle();
+
+  if (invErr || !invRow?.id) {
+    return new NextResponse(invErr?.message || 'Create invitation failed', { status: 400 });
+  }
+
+  if (inv.date_display || inv.location) {
+    const eventsPayload = [
+      {
+        invitation_id: invRow.id,
+        type: 'akad',
+        title: 'Akad Nikah',
+        date_display: inv.date_display || null,
+        location: inv.location || null,
+      },
+      {
+        invitation_id: invRow.id,
+        type: 'resepsi',
+        title: 'Resepsi',
+        date_display: inv.date_display || null,
+        location: inv.location || null,
+      },
+    ];
+
+    const { error: eventErr } = await supabaseAdmin.from('events').insert(eventsPayload);
+
+    if (eventErr) {
+      return new NextResponse(eventErr.message, { status: 400 });
+    }
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      user_id,
+      slug: baseSlug,
+      next: '/client/login?created=1',
+    },
+    { status: 201 }
+  );
+}

--- a/app/api/themes-active/route.ts
+++ b/app/api/themes-active/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+export async function GET() {
+  const { data, error } = await supabaseAdmin
+    .from('themes')
+    .select('slug,name')
+    .eq('status', 'active')
+    .order('name');
+
+  if (error) {
+    return new NextResponse(error.message, { status: 400 });
+  }
+
+  return NextResponse.json(data ?? []);
+}

--- a/app/client/register/page.tsx
+++ b/app/client/register/page.tsx
@@ -1,72 +1,298 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 
-import { sb } from '@/lib/supabaseBrowser';
+type Theme = { slug: string; name: string };
 
-export default function ClientRegister() {
-  const [err, setErr] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const router = useRouter();
+type Step = 1 | 2;
 
-  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setErr(null);
-    setLoading(true);
-    const fd = new FormData(e.currentTarget);
-    const full_name = String(fd.get('full_name') || '');
-    const email = String(fd.get('email') || '');
-    const password = String(fd.get('password') || '');
-    const groom = String(fd.get('groom_name') || '');
-    const bride = String(fd.get('bride_name') || '');
+export default function RegisterPage() {
+  const [step, setStep] = useState<Step>(1);
+  const [themes, setThemes] = useState<Theme[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
 
-    const { error: e1 } = await sb.auth.signUp({
-      email,
-      password,
-      options: { emailRedirectTo: `${location.origin}/auth/callback` },
-    });
-    if (e1) {
-      setLoading(false);
-      return setErr(e1.message);
+  const [email, setEmail] = useState('');
+  const [pass, setPass] = useState('');
+  const [name, setName] = useState('');
+
+  const [groom, setGroom] = useState('');
+  const [bride, setBride] = useState('');
+  const [themeSlug, setThemeSlug] = useState('');
+  const [slug, setSlug] = useState('');
+  const [dateDisplay, setDateDisplay] = useState('');
+  const [location, setLocation] = useState('');
+
+  useEffect(() => {
+    let active = true;
+
+    (async () => {
+      try {
+        const response = await fetch('/api/themes-active');
+        if (!active) return;
+
+        if (response.ok) {
+          const data: Theme[] = await response.json();
+          setThemes(data);
+          if (!themeSlug && data[0]) {
+            setThemeSlug(data[0].slug);
+          }
+        } else {
+          throw new Error('Failed to load themes');
+        }
+      } catch (error) {
+        const fallback: Theme[] = [{ slug: 'jawabiru', name: 'Jawa Biru' }];
+        setThemes(fallback);
+        if (!themeSlug) {
+          setThemeSlug(fallback[0].slug);
+        }
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!themeSlug && themes[0]) {
+      setThemeSlug(themes[0].slug);
     }
+  }, [themes, themeSlug]);
+
+  const canProceedAccount = useMemo(() => !!email && !!pass && !!name, [email, pass, name]);
+  const canSubmitInvitation = useMemo(
+    () => !!groom && !!bride && !!themeSlug,
+    [groom, bride, themeSlug]
+  );
+
+  function handleAccountSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canProceedAccount) {
+      setMessage('Lengkapi informasi akun terlebih dahulu.');
+      return;
+    }
+    setMessage(null);
+    setStep(2);
+  }
+
+  function autoSlug() {
+    const generated = `${groom}-${bride}`
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '');
+    setSlug(generated);
+  }
+
+  async function submitInvitation(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmitInvitation) {
+      setMessage('Lengkapi detail undangan terlebih dahulu.');
+      return;
+    }
+
+    setBusy(true);
+    setMessage(null);
+    setSuccess(false);
 
     try {
-      await fetch('/api/onboarding/create-invitation', {
+      const payload = {
+        account: { email, password: pass, full_name: name },
+        invitation: {
+          slug: slug || undefined,
+          title: `The Wedding of ${groom} & ${bride}`,
+          groom_name: groom,
+          bride_name: bride,
+          theme_slug: themeSlug,
+          date_display: dateDisplay || undefined,
+          location: location || undefined,
+        },
+        options: { confirmEmail: true },
+      };
+
+      const response = await fetch('/api/public/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ full_name, groom_name: groom, bride_name: bride }),
+        body: JSON.stringify(payload),
       });
-    } catch (error) {
-      console.error(error);
-    }
 
-    setLoading(false);
-    router.replace('/client/login');
+      if (!response.ok) {
+        const text = await response.text();
+        setMessage(text || 'Gagal membuat akun.');
+        return;
+      }
+
+      setSuccess(true);
+      setMessage(null);
+    } catch (error) {
+      setMessage('Terjadi kesalahan. Silakan coba lagi.');
+    } finally {
+      setBusy(false);
+    }
   }
 
   return (
-    <div className="min-h-screen grid place-items-center p-6">
-      <form onSubmit={onSubmit} className="w-full max-w-lg space-y-4 rounded-xl bg-white p-6 shadow">
+    <div className="min-h-screen bg-slate-50">
+      <div className="mx-auto max-w-xl space-y-6 p-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-xl font-semibold">Daftar Akun</h1>
+          <h1 className="text-2xl font-semibold">Daftar &amp; Buat Undangan</h1>
           <Link href="/" className="text-sm text-slate-600 hover:underline">
             ← Kembali ke Beranda
           </Link>
         </div>
-        <input name="full_name" required placeholder="Nama Lengkap" className="w-full rounded border px-3 py-2" />
-        <input name="email" type="email" required placeholder="Email" className="w-full rounded border px-3 py-2" />
-        <input name="password" type="password" required placeholder="Password" className="w-full rounded border px-3 py-2" />
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          <input name="groom_name" placeholder="Nama Mempelai Pria" className="rounded border px-3 py-2" />
-          <input name="bride_name" placeholder="Nama Mempelai Wanita" className="rounded border px-3 py-2" />
+
+        <div className="flex gap-2 text-sm">
+          <span className={step === 1 ? 'font-semibold text-slate-900' : 'text-slate-500'}>
+            1. Akun
+          </span>
+          <span>→</span>
+          <span className={step === 2 ? 'font-semibold text-slate-900' : 'text-slate-500'}>
+            2. Detail Undangan
+          </span>
         </div>
-        {err && <p className="text-sm text-rose-600">{err}</p>}
-        <button disabled={loading} className="w-full rounded bg-emerald-600 py-2 text-white">
-          {loading ? 'Mendaftar…' : 'Buat Akun'}
-        </button>
-      </form>
+
+        {step === 1 && (
+          <form onSubmit={handleAccountSubmit} className="grid gap-3 rounded bg-white p-5 shadow">
+            <Input label="Nama Lengkap" value={name} onChange={setName} required />
+            <Input label="Email" type="email" value={email} onChange={setEmail} required />
+            <Input label="Password" type="password" value={pass} onChange={setPass} required />
+            {message && <p className="text-sm text-rose-600">{message}</p>}
+            <div className="flex flex-wrap gap-3">
+              <button className="rounded bg-slate-900 px-4 py-2 text-white" disabled={!canProceedAccount}>
+                Lanjut
+              </button>
+              <Link href="/client/login" className="rounded border px-4 py-2 text-sm">
+                Sudah punya akun?
+              </Link>
+            </div>
+          </form>
+        )}
+
+        {step === 2 && (
+          <form onSubmit={submitInvitation} className="grid gap-3 rounded bg-white p-5 shadow">
+            <div className="grid gap-3 md:grid-cols-2">
+              <Input
+                label="Nama Mempelai Pria"
+                value={groom}
+                onChange={setGroom}
+                required
+              />
+              <Input
+                label="Nama Mempelai Wanita"
+                value={bride}
+                onChange={setBride}
+                required
+              />
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-3">
+              <Input
+                label="Slug (opsional)"
+                value={slug}
+                onChange={setSlug}
+                hint="Contoh: rahmat-nisa"
+                action={{ label: 'Auto', onClick: autoSlug }}
+              />
+              <Input
+                label="Tanggal (opsional)"
+                value={dateDisplay}
+                onChange={setDateDisplay}
+                hint="Contoh: 17 Agustus 2024"
+              />
+              <Input
+                label="Lokasi (opsional)"
+                value={location}
+                onChange={setLocation}
+              />
+            </div>
+
+            <label className="block">
+              <div className="mb-1 text-sm">Tema Undangan</div>
+              <select
+                className="w-full rounded border px-3 py-2"
+                value={themeSlug}
+                onChange={(e) => setThemeSlug(e.target.value)}
+                required
+              >
+                {themes.map((t) => (
+                  <option key={t.slug} value={t.slug}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {message && <p className="text-sm text-rose-600">{message}</p>}
+            {success && (
+              <div className="rounded border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+                Akun dibuat, cek email verifikasi.
+              </div>
+            )}
+
+            <div className="flex flex-wrap gap-3">
+              <button
+                disabled={busy || !canSubmitInvitation}
+                className="rounded bg-slate-900 px-4 py-2 text-white disabled:opacity-70"
+              >
+                {busy ? 'Memproses…' : 'Buat Akun & Undangan'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setStep(1)}
+                className="rounded border px-4 py-2 text-sm"
+              >
+                Kembali
+              </button>
+              <Link
+                href="/client/login?created=1"
+                className="rounded border border-slate-300 px-4 py-2 text-sm text-slate-700"
+              >
+                Ke Halaman Login
+              </Link>
+            </div>
+          </form>
+        )}
+      </div>
     </div>
+  );
+}
+
+type InputProps = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  type?: string;
+  required?: boolean;
+  hint?: string;
+  action?: { label: string; onClick: () => void };
+};
+
+function Input({ label, value, onChange, type = 'text', required, hint, action }: InputProps) {
+  return (
+    <label className="block">
+      <div className="mb-1 flex items-center justify-between text-sm">
+        <span>{label}</span>
+        {action && (
+          <button
+            type="button"
+            onClick={action.onClick}
+            className="rounded border px-2 py-1 text-xs"
+          >
+            {action.label}
+          </button>
+        )}
+      </div>
+      <input
+        className="w-full rounded border px-3 py-2"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        type={type}
+        required={required}
+      />
+      {hint && <div className="mt-1 text-xs text-slate-500">{hint}</div>}
+    </label>
   );
 }

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,12 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 
-export function getAdminClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-  if (!url || !key) {
-    throw new Error('Missing SUPABASE URL or SERVICE ROLE KEY');
+export const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
   }
-  return createClient(url, key, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
-}
+);


### PR DESCRIPTION
## Summary
- add service role Supabase admin client helper
- implement public register API to create users and invitations via Supabase Admin API
- create active themes endpoint and redesign client register page as a two-step wizard with theme selection and success messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e32c34efb88324b406ab467e586d4e