### PR TITLE
Fix missing admin client export

### DIFF
--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -10,3 +10,7 @@ export const supabaseAdmin = createClient(
     },
   }
 );
+
+export function getAdminClient() {
+  return supabaseAdmin;
+}


### PR DESCRIPTION
## Summary
- add a getAdminClient helper that returns the shared Supabase admin client

## Testing
- npm run build *(fails: missing env NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68e32d3a53c88324956b477ff076a91b