### PR TITLE
fix(admin-branding): use admin-only blob upload URL and save logo to settings

### DIFF
--- a/app/api/blob/admin-upload-url/route.ts
+++ b/app/api/blob/admin-upload-url/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { createUploadURL } from '@vercel/blob';
+
+import { getServerClient } from '@/lib/supabaseServer';
+
+export const runtime = 'edge';
+
+export async function GET(req: Request) {
+  const supabase = getServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('is_admin, role')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    return new NextResponse(profileError.message, { status: 400 });
+  }
+
+  const isAdmin = !!profile && (profile.is_admin === true || profile.role === 'admin');
+  if (!isAdmin) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const contentType = url.searchParams.get('contentType') || undefined;
+
+  const uploadUrl = await createUploadURL({
+    access: 'public',
+    token: process.env.BLOB_READ_WRITE_TOKEN!,
+    contentType,
+  });
+
+  return NextResponse.json({ url: uploadUrl });
+}


### PR DESCRIPTION
## Summary
- add an admin-only blob upload URL endpoint for brand logo uploads that validates Supabase admin role
- merge existing branding settings when saving the logo URL to avoid overwriting other keys
- update the admin logo uploader UI to use the new endpoint, handle blob upload responses, and surface clearer status messaging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e331a524e083249f7661503ea0512b