### PR TITLE
fix(auth+blob): reliable email verification flow & admin logo upload

### DIFF
--- a/app/api/blob/admin-upload-url/route.ts
+++ b/app/api/blob/admin-upload-url/route.ts
@@ -1,49 +1,53 @@
 import { NextResponse } from 'next/server';
-import { getServerClient } from '@/lib/supabaseServer';
-import { createUploadUrl } from '@/lib/vercelBlob';
-import type { Profile } from '@/types/db';
+import { createUploadURL } from '@vercel/blob';
 
-export const runtime = 'edge';
+import { getServerClient } from '@/lib/supabaseServer';
+
+export const runtime = 'nodejs';
 
 export async function GET(req: Request) {
-  const supabase = getServerClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) {
-    return new NextResponse('Unauthorized', { status: 401 });
+  try {
+    const supabase = getServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return new NextResponse('Unauthorized', { status: 401 });
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('is_admin, role')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (profileError) {
+      return new NextResponse(profileError.message, { status: 400 });
+    }
+
+    const isAdmin = !!profile && (profile.is_admin === true || profile.role === 'admin');
+    if (!isAdmin) {
+      return new NextResponse('Forbidden', { status: 403 });
+    }
+
+    const token = process.env.BLOB_READ_WRITE_TOKEN;
+    if (!token) {
+      return new NextResponse('Missing BLOB_READ_WRITE_TOKEN', { status: 500 });
+    }
+
+    const urlObj = new URL(req.url);
+    const contentType = urlObj.searchParams.get('contentType') || 'image/png';
+
+    const uploadUrl = await createUploadURL({
+      access: 'public',
+      token,
+      contentType,
+    });
+
+    return NextResponse.json({ url: uploadUrl });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return new NextResponse(`Blob error: ${message}`, { status: 500 });
   }
-
-  type ProfileRoleInfo = Pick<Profile, 'is_admin' | 'role'>;
-
-  const { data: profile, error: profileError } = await supabase
-    .from('profiles')
-    .select('is_admin, role')
-    .eq('user_id', user.id)
-    .maybeSingle<ProfileRoleInfo>();
-
-  if (profileError) {
-    return new NextResponse(profileError.message, { status: 400 });
-  }
-
-  const isAdmin = !!profile && (profile.is_admin === true || profile.role === 'admin');
-  if (!isAdmin) {
-    return new NextResponse('Forbidden', { status: 403 });
-  }
-
-  const url = new URL(req.url);
-  const contentType = url.searchParams.get('contentType') || undefined;
-
-  const blobToken = process.env.BLOB_READ_WRITE_TOKEN;
-  if (!blobToken) {
-    return new NextResponse('Blob token missing', { status: 500 });
-  }
-
-  const uploadUrl = await createUploadUrl({
-    access: 'public',
-    token: blobToken,
-    contentType,
-  });
-
-  return NextResponse.json({ url: uploadUrl });
 }

--- a/app/api/public/register-finalize/route.ts
+++ b/app/api/public/register-finalize/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+type Payload = {
+  user_id: string;
+  account: { email: string; full_name?: string | null };
+  invitation: {
+    slug?: string;
+    groom_name: string;
+    bride_name: string;
+    title?: string;
+    theme_slug: string;
+    date_display?: string | null;
+    location?: string | null;
+  };
+};
+
+const admin = () =>
+  createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  );
+
+const slugify = (s: string) =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 60);
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => null)) as Payload | null;
+  const { user_id, account, invitation } = body || {};
+
+  if (!user_id || !account?.email || !invitation?.groom_name || !invitation?.bride_name || !invitation?.theme_slug) {
+    return new NextResponse('Missing fields', { status: 400 });
+  }
+
+  const db = admin();
+
+  const { data: theme, error: themeError } = await db
+    .from('themes')
+    .select('slug,status')
+    .eq('slug', invitation.theme_slug)
+    .eq('status', 'active')
+    .maybeSingle();
+  if (themeError) {
+    return new NextResponse(themeError.message, { status: 400 });
+  }
+  if (!theme) {
+    return new NextResponse('Theme not available', { status: 400 });
+  }
+
+  const base = invitation.slug?.trim() || slugify(`${invitation.groom_name}-${invitation.bride_name}`);
+  if (!base) {
+    return new NextResponse('Slug required', { status: 400 });
+  }
+
+  const { data: exist, error: slugError } = await db
+    .from('invitations')
+    .select('id')
+    .eq('slug', base)
+    .maybeSingle();
+  if (slugError) {
+    return new NextResponse(slugError.message, { status: 400 });
+  }
+  if (exist) {
+    return new NextResponse('Slug already taken', { status: 409 });
+  }
+
+  const { error: profileErr } = await db
+    .from('profiles')
+    .upsert(
+      {
+        user_id,
+        email: account.email,
+        full_name: account.full_name ?? null,
+        is_admin: false,
+      },
+      { onConflict: 'user_id' }
+    );
+
+  if (profileErr) {
+    return new NextResponse(profileErr.message, { status: 400 });
+  }
+
+  const now = new Date().toISOString();
+  const { data: inserted, error: invErr } = await db
+    .from('invitations')
+    .insert({
+      user_id,
+      slug: base,
+      title: invitation.title || `The Wedding of ${invitation.groom_name} & ${invitation.bride_name}`,
+      groom_name: invitation.groom_name,
+      bride_name: invitation.bride_name,
+      theme_slug: theme.slug,
+      date_display: invitation.date_display ?? null,
+      music_url: null,
+      cover_photo_url: null,
+      pages_enabled: {
+        cover: true,
+        couple: true,
+        event: true,
+        wishes: true,
+        gallery: true,
+        story: true,
+        location: true,
+        qrcode: true,
+        prokes: false,
+        gift: true,
+      },
+      is_published: false,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('id')
+    .maybeSingle();
+
+  if (invErr) {
+    return new NextResponse(invErr.message, { status: 400 });
+  }
+
+  if (inserted?.id && (invitation.date_display || invitation.location)) {
+    const eventsPayload = [
+      {
+        invitation_id: inserted.id,
+        type: 'akad',
+        title: 'Akad Nikah',
+        date_display: invitation.date_display ?? null,
+        location: invitation.location ?? null,
+      },
+      {
+        invitation_id: inserted.id,
+        type: 'resepsi',
+        title: 'Resepsi',
+        date_display: invitation.date_display ?? null,
+        location: invitation.location ?? null,
+      },
+    ];
+
+    await db.from('events').insert(eventsPayload).catch(() => undefined);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/public/resend-verification/route.ts
+++ b/app/api/public/resend-verification/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+import { supabaseAnon } from '@/lib/supabaseAnon';
+
+export async function POST(req: Request) {
+  const { email } = (await req.json().catch(() => ({}))) as { email?: string };
+  if (!email) {
+    return new NextResponse('email required', { status: 400 });
+  }
+
+  const { error } = await supabaseAnon.auth.resend({
+    email,
+    type: 'signup',
+    options: {
+      emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}/auth/callback`,
+    },
+  });
+
+  if (error) {
+    return new NextResponse(error.message, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,0 +1,13 @@
+export default function CallbackPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-semibold">Email terverifikasi</h1>
+        <p className="opacity-70">Silakan login untuk mulai mengelola undangan.</p>
+        <a className="underline" href="/client/login">
+          Ke halaman login
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/app/client/login/ClientLoginForm.tsx
+++ b/app/client/login/ClientLoginForm.tsx
@@ -10,6 +10,11 @@ import { sb } from '@/lib/supabaseBrowser';
 export default function ClientLoginForm() {
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [resendMessage, setResendMessage] = useState<string | null>(null);
+  const [resendStatus, setResendStatus] = useState<'success' | 'error' | null>(null);
+  const [resending, setResending] = useState(false);
   const sp = useSearchParams();
   const router = useRouter();
   const nextUrl = sp.get('next') || '/client';
@@ -19,11 +24,8 @@ export default function ClientLoginForm() {
     e.preventDefault();
     if (loading) return;
     setErr(null);
+    setResendMessage(null);
     setLoading(true);
-
-    const fd = new FormData(e.currentTarget);
-    const email = String(fd.get('email') || '');
-    const password = String(fd.get('password') || '');
 
     const { data, error } = await sb.auth.signInWithPassword({ email, password });
     if (error || !data.session) {
@@ -50,6 +52,43 @@ export default function ClientLoginForm() {
     window.location.assign(nextUrl);
   }
 
+  async function handleResend() {
+    if (resending) return;
+    if (!email) {
+      setResendStatus('error');
+      setResendMessage('Masukkan email terlebih dahulu.');
+      return;
+    }
+
+    setResending(true);
+    setResendStatus(null);
+    setResendMessage(null);
+
+    try {
+      const response = await fetch('/api/public/resend-verification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        setResendStatus('error');
+        setResendMessage(text || 'Gagal mengirim ulang verifikasi.');
+        return;
+      }
+
+      setResendStatus('success');
+      setResendMessage('Email verifikasi dikirim ulang. Silakan cek kotak masuk.');
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Gagal mengirim ulang verifikasi.';
+      setResendStatus('error');
+      setResendMessage(msg);
+    } finally {
+      setResending(false);
+    }
+  }
+
   return (
     <div className="min-h-screen grid place-items-center p-6">
       <form onSubmit={onSubmit} className="w-full max-w-md bg-white shadow rounded-xl p-6 space-y-4">
@@ -60,17 +99,32 @@ export default function ClientLoginForm() {
           </Link>
         </div>
 
-        <input name="email" type="email" required placeholder="Email" className="w-full border rounded px-3 py-2" />
+        <input
+          name="email"
+          type="email"
+          required
+          placeholder="Email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          className="w-full border rounded px-3 py-2"
+        />
         <input
           name="password"
           type="password"
           required
           placeholder="Password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
           className="w-full border rounded px-3 py-2"
         />
 
         {verified && <p className="text-sm text-emerald-600">Email berhasil dikonfirmasi. Silakan login.</p>}
         {err && <p className="text-sm text-rose-600">{err}</p>}
+        {resendMessage && (
+          <p className={`text-sm ${resendStatus === 'success' ? 'text-emerald-600' : 'text-rose-600'}`}>
+            {resendMessage}
+          </p>
+        )}
 
         <button
           disabled={loading}
@@ -78,6 +132,14 @@ export default function ClientLoginForm() {
           type="submit"
         >
           {loading ? 'Masuk…' : 'Masuk'}
+        </button>
+        <button
+          type="button"
+          onClick={handleResend}
+          disabled={resending || !email}
+          className="w-full rounded border border-slate-300 px-3 py-2 text-sm text-slate-700 disabled:opacity-60"
+        >
+          {resending ? 'Mengirim ulang…' : 'Kirim ulang verifikasi'}
         </button>
       </form>
     </div>

--- a/components/LogoUploader.tsx
+++ b/components/LogoUploader.tsx
@@ -22,7 +22,9 @@ export function LogoUploader() {
 
       const uploadUrlRes = await fetch(`/api/blob/admin-upload-url?${params.toString()}`);
       if (!uploadUrlRes.ok) {
-        throw new Error('Tidak dapat membuat upload URL');
+        const text = await uploadUrlRes.text();
+        setError(text || 'Tidak dapat membuat upload URL');
+        return;
       }
 
       const { url } = (await uploadUrlRes.json()) as { url?: string };
@@ -35,7 +37,8 @@ export function LogoUploader() {
         body: file,
       });
       if (!blobRes.ok) {
-        throw new Error('Upload gagal');
+        const text = await blobRes.text();
+        throw new Error(text || 'Upload gagal');
       }
 
       const blobUrl =

--- a/lib/supabaseAnon.ts
+++ b/lib/supabaseAnon.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabaseAnon = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);


### PR DESCRIPTION
## Summary
- switch client registration to Supabase signUp and finalize via a new server endpoint, plus add a verification callback page and resend-verification API
- provide an anon Supabase helper and expose a resend verification control on the client login form
- harden the admin logo upload flow by using the Blob SDK on Node runtime and surfacing server error messages in the UI

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68e33ce07f44832483f1bed8621c0053