### PR TITLE
Fix blob admin upload endpoint and guard Supabase client setup

### DIFF
--- a/app/api/blob/admin-upload-url/route.ts
+++ b/app/api/blob/admin-upload-url/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { createUploadURL } from '@vercel/blob';
-
 import { getServerClient } from '@/lib/supabaseServer';
+import { createUploadUrl } from '@/lib/vercelBlob';
+import type { Profile } from '@/types/db';
 
 export const runtime = 'nodejs';
 
@@ -16,11 +16,13 @@ export async function GET(req: Request) {
       return new NextResponse('Unauthorized', { status: 401 });
     }
 
+    type ProfileRoleInfo = Pick<Profile, 'is_admin' | 'role'>;
+
     const { data: profile, error: profileError } = await supabase
       .from('profiles')
       .select('is_admin, role')
       .eq('user_id', user.id)
-      .maybeSingle();
+      .maybeSingle<ProfileRoleInfo>();
 
     if (profileError) {
       return new NextResponse(profileError.message, { status: 400 });
@@ -39,7 +41,7 @@ export async function GET(req: Request) {
     const urlObj = new URL(req.url);
     const contentType = urlObj.searchParams.get('contentType') || 'image/png';
 
-    const uploadUrl = await createUploadURL({
+    const uploadUrl = await createUploadUrl({
       access: 'public',
       token,
       contentType,

--- a/app/api/public/register-finalize/route.ts
+++ b/app/api/public/register-finalize/route.ts
@@ -139,7 +139,10 @@ export async function POST(req: Request) {
       },
     ];
 
-    await db.from('events').insert(eventsPayload).catch(() => undefined);
+    const { error: eventsError } = await db.from('events').insert(eventsPayload);
+    if (eventsError) {
+      console.warn('[register-finalize] failed to insert default events', eventsError);
+    }
   }
 
   return NextResponse.json({ ok: true });

--- a/app/api/public/resend-verification/route.ts
+++ b/app/api/public/resend-verification/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-import { supabaseAnon } from '@/lib/supabaseAnon';
+import { getSupabaseAnonClient } from '@/lib/supabaseAnon';
 
 export async function POST(req: Request) {
   const { email } = (await req.json().catch(() => ({}))) as { email?: string };
@@ -8,7 +8,15 @@ export async function POST(req: Request) {
     return new NextResponse('email required', { status: 400 });
   }
 
-  const { error } = await supabaseAnon.auth.resend({
+  let supabase;
+  try {
+    supabase = getSupabaseAnonClient();
+  } catch (error) {
+    console.error('[resend-verification] Supabase client missing', error);
+    return new NextResponse('Supabase client not configured', { status: 500 });
+  }
+
+  const { error } = await supabase.auth.resend({
     email,
     type: 'signup',
     options: {

--- a/lib/supabaseAnon.ts
+++ b/lib/supabaseAnon.ts
@@ -1,6 +1,18 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-export const supabaseAnon = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+let cachedClient: SupabaseClient | null = null;
+
+export function getSupabaseAnonClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Supabase anonymous client is not configured');
+  }
+
+  if (!cachedClient) {
+    cachedClient = createClient(supabaseUrl, supabaseAnonKey);
+  }
+
+  return cachedClient;
+}


### PR DESCRIPTION
## Summary
- replace the removed `@vercel/blob` helper in the admin upload route with the existing blob helper and type the profile lookup
- avoid chaining `.catch` on the Supabase query builder when seeding default events and log any failure instead
- lazily initialize the Supabase anon client and return a clear error from the resend verification route when configuration is missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3423189248324bd34369d058fc212