### PR TITLE
Handle delayed user replication when creating profiles

### DIFF
--- a/app/api/public/register/route.ts
+++ b/app/api/public/register/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { upsertProfileWithRetry } from '@/lib/upsertProfileWithRetry';
 
 type Payload = {
   account: { email: string; password: string; full_name?: string };
@@ -84,15 +85,12 @@ export async function POST(req: Request) {
 
   const user_id = createdUser.user.id;
 
-  const { error: profileErr } = await supabaseAdmin.from('profiles').upsert(
-    {
-      user_id,
-      email,
-      full_name,
-      is_admin: false,
-    },
-    { onConflict: 'user_id' }
-  );
+  const { error: profileErr } = await upsertProfileWithRetry(supabaseAdmin, {
+    user_id,
+    email,
+    full_name,
+    is_admin: false,
+  });
 
   if (profileErr) {
     return new NextResponse(profileErr.message, { status: 400 });

--- a/lib/upsertProfileWithRetry.ts
+++ b/lib/upsertProfileWithRetry.ts
@@ -1,0 +1,49 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { Database } from '@/types/db';
+
+const RETRYABLE_PG_ERROR_CODES = new Set(['23503']);
+
+type ProfileInsert = Database['public']['Tables']['profiles']['Insert'];
+
+/**
+ * Attempts to upsert a profile row, retrying when the auth.users FK has not yet replicated.
+ */
+export async function upsertProfileWithRetry(
+  client: SupabaseClient<Database>,
+  payload: ProfileInsert,
+  {
+    retries = 5,
+    initialDelayMs = 200,
+  }: { retries?: number; initialDelayMs?: number } = {}
+) {
+  let attempt = 0;
+  let delay = initialDelayMs;
+  let lastError: { message: string; code?: string } | null = null;
+
+  while (attempt <= retries) {
+    const { error } = await client
+      .from('profiles')
+      .upsert(payload, { onConflict: 'user_id' });
+
+    if (!error) {
+      return { error: null } as const;
+    }
+
+    lastError = error;
+
+    if (!error.code || !RETRYABLE_PG_ERROR_CODES.has(error.code)) {
+      break;
+    }
+
+    attempt += 1;
+    if (attempt > retries) {
+      break;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    delay *= 2;
+  }
+
+  return { error: lastError } as const;
+}


### PR DESCRIPTION
## Summary
- add a reusable helper that retries profile upserts when the auth.users record has not replicated yet
- use the retrying helper in the public registration APIs to avoid foreign key violations while creating profiles

## Testing
- npm run lint *(fails: next not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e345790904832490a7d94591d3369f