### PR TITLE
Fix Supabase guest insert typing in public wishes API

### DIFF
--- a/app/api/public/wishes/route.ts
+++ b/app/api/public/wishes/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { getServerClient } from '@/lib/supabaseServer';
+import type { Database } from '@/types/db';
 
 const rateLimitStore = new Map<string, number>();
 const RATE_LIMIT_WINDOW = 60 * 1000;
@@ -61,7 +62,7 @@ export async function POST(request: Request) {
       name,
       message,
       status: 'pending',
-    });
+    } satisfies Database['public']['Tables']['guests']['Insert']);
 
     if (error) {
       return new NextResponse(error.message, { status: 400 });


### PR DESCRIPTION
## Summary
- ensure the public wishes API uses the generated Supabase database types when inserting guests

## Testing
- npm run build *(fails: missing env vars and missing optional dependencies `lucide-react`, `qrcode.react` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e38743b5fc8324bf1f07e19df799fd