### PR TITLE
Ensure Supabase server client preserves public schema typing

### DIFF
--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -7,9 +7,9 @@ import type { Database } from '@/types/db';
 const fallbackUrl = 'https://placeholder.supabase.co';
 const fallbackAnonKey = 'public-anon-key';
 
-export function getServerClient(): SupabaseClient<Database> {
+export function getServerClient(): SupabaseClient<Database, 'public', Database['public']> {
   const cookieStore = cookies();
-  return createServerClient<Database, 'public'>(
+  return createServerClient<Database, 'public', Database['public']>(
     process.env.NEXT_PUBLIC_SUPABASE_URL || fallbackUrl,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || fallbackAnonKey,
     {


### PR DESCRIPTION
## Summary
- update the Supabase server client factory to include the public schema type parameter
- ensure inserts into the guests table receive proper type inference during builds

## Testing
- npm run build *(fails: missing dependencies `lucide-react`, `qrcode.react`)*

------
https://chatgpt.com/codex/tasks/task_e_68e3890a6e348324bf84e009ed62235d