### PR TITLE
Fix Supabase client typing in onboarding route

### DIFF
--- a/app/api/onboarding/create-invitation/route.ts
+++ b/app/api/onboarding/create-invitation/route.ts
@@ -1,6 +1,5 @@
 import { getServerClient } from '@/lib/supabaseServer';
 import type { Database } from '@/types/db';
-import type { SupabaseClient } from '@supabase/supabase-js';
 
 export async function POST(req: Request) {
   const supabase = getServerClient();
@@ -20,7 +19,7 @@ export async function POST(req: Request) {
     .replace(/(^-|-$)/g, '');
   const slug = base || `undangan-${Date.now()}`;
 
-  const payload: Database['public']['Tables']['invitations']['Insert'] = {
+  const payload = {
     slug,
     title: `The Wedding of ${groom_name} & ${bride_name}`,
     groom_name,
@@ -40,13 +39,11 @@ export async function POST(req: Request) {
       prokes: false,
       gift: true,
     },
-  };
+  } satisfies Database['public']['Tables']['invitations']['Insert'];
 
-  const typedSupabase = supabase as SupabaseClient<Database>;
-  const { error } = await typedSupabase
+  const { error } = await supabase
     .from('invitations')
-    // Supabase client typing fails to infer our table schema, so cast is required.
-    .insert(payload as never);
+    .insert(payload);
 
   if (error) return new Response(error.message, { status: 400 });
 


### PR DESCRIPTION
## Summary
- remove the incorrect cast of the Supabase server client to a generic SupabaseClient
- ensure the invitation payload satisfies the generated Database insert type and insert it without unsafe casts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e38a1a9ce08324a0ff0c857596b2b5