### PR TITLE
Ensure new comments include an id

### DIFF
--- a/components/comments/comment-form.tsx
+++ b/components/comments/comment-form.tsx
@@ -40,6 +40,9 @@ export function CommentForm({ slug, onSubmitted }: CommentFormProps) {
       }
       setStatus('success');
       const newComment: Comment = {
+        id: typeof crypto !== 'undefined' && 'randomUUID' in crypto
+          ? crypto.randomUUID()
+          : `${Date.now()}`,
         nama,
         pesan,
         waktuISO: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- ensure the comment form assigns an id when creating a new comment so it matches the `Comment` type

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4e9de1f708324bcb40ba836ee320f