### PR TITLE
Improve landing page layout styling

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,7 +1,3 @@
-@import url('https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css');
-@import url('https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css');
-@import url('/themes/undangan-4x/css/undangan4x.css');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -16,7 +12,7 @@ html {
 
 body {
   min-height: 100vh;
-  background-color: #0b1220;
+  background-color: #f8fafc;
 }
 
 a {
@@ -30,4 +26,30 @@ a:hover {
 
 ::selection {
   background-color: rgba(124, 58, 237, 0.35);
+}
+
+@layer components {
+  .container-wide {
+    @apply mx-auto w-full max-w-6xl px-6 md:px-8;
+  }
+
+  .container-narrow {
+    @apply mx-auto w-full max-w-4xl px-6 md:px-8;
+  }
+
+  .section {
+    @apply py-16 md:py-24;
+  }
+
+  .section-muted {
+    @apply section bg-slate-100/80;
+  }
+
+  .section-dark {
+    @apply section bg-slate-900 text-slate-100;
+  }
+
+  .card {
+    @apply rounded-3xl border border-slate-200/70 bg-white p-6 shadow-sm shadow-slate-900/5 transition hover:-translate-y-0.5 hover:shadow-md;
+  }
 }


### PR DESCRIPTION
## Summary
- remove legacy global CSS imports that conflicted with the landing page styling
- add Tailwind utility layers for shared containers, sections, and cards to restore spacing and hierarchy
- reset the body background to a light neutral color for better contrast

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5c06f33d0832496a67f6bb1c88efa