### PR TITLE
feat: port undangan 4.x theme to Next.js route

### DIFF
--- a/app/api/ucapan/route.ts
+++ b/app/api/ucapan/route.ts
@@ -1,18 +1,18 @@
 import { NextResponse } from 'next/server';
 
+interface Body {
+  nama?: string;
+  pesan?: string;
+}
+
 export async function POST(request: Request) {
-  try {
-    const body = await request.json();
-    const nama = typeof body.nama === 'string' ? body.nama.trim() : '';
-    const pesan = typeof body.pesan === 'string' ? body.pesan.trim() : '';
+  const data = (await request.json()) as Body;
+  const nama = data?.nama?.trim();
+  const pesan = data?.pesan?.trim();
 
-    if (nama.length < 2 || pesan.length < 1) {
-      return NextResponse.json({ ok: false, message: 'Data tidak valid.' }, { status: 400 });
-    }
-
-    return NextResponse.json({ ok: true });
-  } catch (error) {
-    console.error('[ucapan] Failed to parse request', error);
-    return NextResponse.json({ ok: false, message: 'Terjadi kesalahan pada server.' }, { status: 500 });
+  if (!nama || !pesan) {
+    return NextResponse.json({ ok: false, message: 'Nama dan pesan wajib diisi.' }, { status: 400 });
   }
+
+  return NextResponse.json({ ok: true });
 }

--- a/app/undangan/[slug]/data.ts
+++ b/app/undangan/[slug]/data.ts
@@ -1,0 +1,115 @@
+import { gcalEventUrl } from '@/lib/gcal';
+import { getSiteUrl } from '@/lib/getSiteUrl';
+import type { InvitationContent } from '@/lib/types';
+
+const BASE_SLUG = 'contoh-rahmat-nisa';
+
+export function getInvitation(slug: string): InvitationContent | null {
+  if (slug !== BASE_SLUG) {
+    return null;
+  }
+
+  const detailsUrl = `${getSiteUrl()}/undangan/${slug}`;
+
+  const schedules = [
+    {
+      title: 'Akad',
+      start: '2023-03-15T09:00:00+07:00',
+      end: '2023-03-15T11:00:00+07:00',
+      timeLabel: 'Pukul 09.00 - 11.00 WIB',
+    },
+    {
+      title: 'Resepsi',
+      start: '2023-03-15T12:30:00+07:00',
+      end: '2023-03-15T15:30:00+07:00',
+      timeLabel: 'Pukul 12.30 - 15.30 WIB',
+    },
+  ];
+
+  return {
+    slug,
+    hero: {
+      title: 'Rahmat & Nisa',
+      subtitle: 'Rabu, 15 Maret 2023',
+      backgroundImage: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80',
+      backgroundAlt: 'Background romantis',
+      avatarImage: 'https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=600&q=80',
+      avatarAlt: 'Rahmat dan Nisa',
+      googleCalendarUrl: gcalEventUrl(
+        'Rahmat & Nisa Wedding',
+        schedules[0].start,
+        schedules[1].end,
+        'Aula Serbaguna Bahagia, Banyumas',
+        detailsUrl
+      ),
+    },
+    couple: {
+      groom: {
+        name: 'Rahmat Prasetyo Putra',
+        role: 'Putra pertama',
+        parents: ['Bapak Ahmad Prasetyo', 'dan', 'Ibu Nur Aisyah'],
+        image: 'https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=600&q=80',
+      },
+      bride: {
+        name: 'Hanisa Dewi Lestari',
+        role: 'Putri kedua',
+        parents: ['Bapak Sutrisno', 'dan', 'Ibu Rahayu Wulandari'],
+        image: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=600&q=80',
+      },
+    },
+    schedules,
+    headline: 'Moment Bahagia',
+    description:
+      'Dengan memohon rahmat dan ridho Allah Subhanahu Wa Ta\'ala, insyaAllah kami akan menyelenggarakan acara:',
+    dressCode: 'Busana batik dan bersepatu.',
+    mapUrl: 'https://goo.gl/maps/ALZR6FJZU3kxVwN86',
+    venue: 'Aula Serbaguna Bahagia, Desa Pajerukan, Banyumas, Jawa Tengah 53191',
+    gallery: [
+      {
+        src: 'https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=700&q=80&sat=-20',
+        alt: 'Rahmat dan Nisa tersenyum',
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=800&q=80&hue=20',
+        alt: 'Momen cincin pernikahan',
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=750&q=80&sat=-50',
+        alt: 'Suasana resepsi',
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1519223400710-6da9e1b777ea?auto=format&fit=crop&w=650&q=80',
+        alt: 'Foto keluarga bahagia',
+      },
+    ],
+    messages: [
+      {
+        id: '1',
+        name: 'Dewi Lestari',
+        message: 'Selamat menempuh hidup baru, semoga menjadi keluarga sakinah mawaddah warahmah.',
+        status: 'Hadir',
+        createdAt: '1 jam yang lalu',
+      },
+      {
+        id: '2',
+        name: 'Rudi Hartono',
+        message: 'Selamat Rahmat dan Nisa! Mohon maaf belum bisa hadir, semoga acaranya lancar.',
+        status: 'Berhalangan',
+        createdAt: '3 jam yang lalu',
+      },
+      {
+        id: '3',
+        name: 'Siti Fauziah',
+        message: 'Ikut bahagia mendengar kabar baik ini. Sampai jumpa di hari H!',
+        status: 'Hadir',
+        createdAt: 'Kemarin',
+      },
+    ],
+    stats: {
+      comments: 128,
+      present: 64,
+      absent: 12,
+      likes: 356,
+    },
+  };
+}

--- a/app/undangan/[slug]/head.tsx
+++ b/app/undangan/[slug]/head.tsx
@@ -1,0 +1,17 @@
+export default function InvitationHead() {
+  return (
+    <>
+      <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        integrity="sha384-vuS0mXqdijbG8ZQzQ0jrISFRCGDpa2BkLomqKgkl0vvVuv5AO9M/dwZ0pniNXh5H"
+        crossOrigin="anonymous"
+      />
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Sacramento&family=Noto+Naskh+Arabic&display=swap"
+      />
+      <link rel="stylesheet" href="/themes/undangan-4x/css/undangan4x.css" />
+    </>
+  );
+}

--- a/app/undangan/[slug]/layout.tsx
+++ b/app/undangan/[slug]/layout.tsx
@@ -1,14 +1,13 @@
 import type { ReactNode } from 'react';
-
-import { Tabbar } from '@/components/tabbar';
+import Script from 'next/script';
+import { BootstrapThemeClient } from '@/components/legacy/BootstrapThemeClient';
 
 export default function InvitationLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen bg-[#0B1220] text-white">
-      <main className="relative mx-auto flex min-h-screen max-w-5xl flex-col gap-10 px-4 pb-24 pt-6 sm:px-6">
-        {children}
-      </main>
-      <Tabbar />
-    </div>
+    <>
+      <BootstrapThemeClient theme="dark" />
+      {children}
+      <Script src="/themes/undangan-4x/js/guest.js" strategy="afterInteractive" />
+    </>
   );
 }

--- a/app/undangan/[slug]/loading.tsx
+++ b/app/undangan/[slug]/loading.tsx
@@ -1,17 +1,7 @@
-import { Skeleton } from '@/components/ui/skeleton';
-
-export default function Loading() {
+export default function InvitationLoading() {
   return (
-    <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-10">
-      <div className="h-[320px] overflow-hidden rounded-3xl border border-white/10 bg-white/5">
-        <Skeleton className="h-full w-full" />
-      </div>
-      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, index) => (
-          <Skeleton key={index} className="h-[150px] rounded-3xl" />
-        ))}
-      </div>
-      <Skeleton className="h-64 rounded-3xl" />
+    <div className="d-flex justify-content-center align-items-center min-vh-100">
+      <div className="spinner-border text-secondary" role="status" aria-label="Memuat undangan" />
     </div>
   );
 }

--- a/app/undangan/[slug]/page.tsx
+++ b/app/undangan/[slug]/page.tsx
@@ -1,135 +1,63 @@
-/* eslint-disable @next/next/no-img-element */
-/**
- * README: Jalankan `npm install` lalu `npm run dev` untuk memulai pengembangan tema undangan.
- */
-
-import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { Hero } from '@/components/legacy/Hero';
+import { SectionGaleri } from '@/components/legacy/SectionGaleri';
+import { SectionMempelai } from '@/components/legacy/SectionMempelai';
+import { SectionTanggal } from '@/components/legacy/SectionTanggal';
+import { SectionUcapan } from '@/components/legacy/SectionUcapan';
+import { Tabbar } from '@/components/legacy/Tabbar';
+import { getInvitation } from './data';
 
-import { Hero } from '@/components/hero';
-import { StatsCards } from '@/components/stats-cards';
-import { MempelaiSection } from '@/components/sections/mempelai';
-import { JadwalSection } from '@/components/sections/jadwal';
-import { GaleriSection } from '@/components/sections/galeri';
-import { UcapanSection } from '@/components/sections/ucapan';
-import { type InvitationContent } from '@/lib/types';
-import { combineDateAndTime, formatIndonesianDate } from '@/lib/utils';
-
-const DEMO_SLUG = 'contoh-rahmat-nisa';
-
-const DEMO_INVITATION: InvitationContent = {
-  couple: {
-    panggilanPria: 'Rahmat',
-    namaPria: 'Rahmat Prasetyo Putra',
-    panggilanWanita: 'Nisa',
-    namaWanita: 'Hanisa Dewi Lestari',
-    fotoCoverUrl:
-      'https://images.unsplash.com/photo-1519741497674-611481863552?auto=format&fit=crop&w=1600&q=80',
-  },
-  events: [
-    {
-      label: 'Akad Nikah',
-      tanggal: '2023-03-15',
-      jamMulai: '09:00',
-      jamSelesai: '11:00',
-      alamat: 'Masjid Raya Al-Falah, Jl. Merpati No. 12, Bandung',
-      gmapsUrl: 'https://maps.app.goo.gl/3pgE3dSa1YV3eYND7',
-    },
-    {
-      label: 'Resepsi',
-      tanggal: '2023-03-15',
-      jamMulai: '12:30',
-      jamSelesai: '15:30',
-      alamat: 'Grand Orchid Ballroom, Jl. Anggrek No. 8, Bandung',
-      gmapsUrl: 'https://maps.app.goo.gl/r5BfJd4drAiXGe3R9',
-    },
-  ],
-  stats: {
-    comments: 128,
-    present: 214,
-    absent: 16,
-    likes: 482,
-  },
-  comments: [
-    {
-      id: 'amira-danu',
-      nama: 'Amira & Danu',
-      pesan: 'Selamat menempuh hidup baru! Semoga rumah tangga Rahmat dan Nisa selalu penuh cinta dan kebahagiaan.',
-      waktuISO: new Date('2023-03-01T08:30:00+07:00').toISOString(),
-    },
-    {
-      id: 'keluarga-wijaya',
-      nama: 'Keluarga Wijaya',
-      pesan: 'Doa terbaik untuk kalian berdua. Semoga menjadi keluarga sakinah, mawaddah, warahmah.',
-      waktuISO: new Date('2023-02-24T09:45:00+07:00').toISOString(),
-    },
-    {
-      id: 'laras',
-      nama: 'Laras',
-      pesan: 'Tidak sabar bertemu kalian di hari bahagia! Congrats!',
-      waktuISO: new Date('2023-02-20T19:12:00+07:00').toISOString(),
-    },
-  ],
-  gallery: [
-    'https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=800&q=80',
-    'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=800&q=80',
-    'https://images.unsplash.com/photo-1519741497674-611481863552?auto=format&fit=crop&w=800&q=80',
-    'https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=800&q=80&sat=-100',
-    'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=800&q=80',
-    'https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?auto=format&fit=crop&w=800&q=80',
-  ],
-  orangTua: {
-    pria: 'Bapak H. Sugeng Raharjo & Ibu Hj. Kartika Sari',
-    wanita: 'Bapak H. Suryo Wibowo & Ibu Hj. Dewi Kartini',
-  },
-};
-
-type PageProps = {
+interface PageProps {
   params: {
     slug: string;
   };
-};
-
-async function getInvitationContent(slug: string): Promise<InvitationContent | null> {
-  if (slug === DEMO_SLUG) {
-    return DEMO_INVITATION;
-  }
-  return null;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const data = await getInvitationContent(params.slug);
-  if (!data) {
-    return {
-      title: 'Undangan Pernikahan',
-      description: 'Undangan digital elegan dengan nuansa gelap dan aksen ungu.',
-    };
-  }
-  const firstEvent = data.events[0];
-  const eventDate = formatIndonesianDate(combineDateAndTime(firstEvent.tanggal, firstEvent.jamMulai));
-  return {
-    title: `${data.couple.panggilanPria} & ${data.couple.panggilanWanita} — ${eventDate}`,
-    description: `Undangan pernikahan ${data.couple.namaPria} & ${data.couple.namaWanita} pada ${eventDate}.`,
-    robots: params.slug === DEMO_SLUG ? { index: false, follow: false } : undefined,
-  };
-}
+export default function InvitationPage({ params }: PageProps) {
+  const invitation = getInvitation(params.slug);
 
-export default async function InvitationPage({ params }: PageProps) {
-  const data = await getInvitationContent(params.slug);
-  if (!data) {
+  if (!invitation) {
     notFound();
   }
 
-  const firstEvent = data.events[0];
-
   return (
-    <div className="space-y-14 pb-12">
-      <Hero couple={data.couple} firstEvent={firstEvent} />
-      <StatsCards stats={data.stats} />
-      <MempelaiSection couple={data.couple} orangTua={data.orangTua} />
-      <JadwalSection events={data.events} />
-      <GaleriSection images={data.gallery} />
-      <UcapanSection slug={params.slug} initialComments={data.comments} />
+    <div id="undangan4x" className="u4x bg-white-black position-relative" data-section-id="root">
+      <main className="position-relative pb-5 mb-5" data-bs-spy="scroll" data-bs-target="#navbar-menu" data-bs-smooth-scroll="true">
+        <Hero hero={invitation.hero} />
+        <SectionMempelai couple={invitation.couple} />
+        <SectionTanggal
+          schedules={invitation.schedules}
+          headline={invitation.headline}
+          description={invitation.description}
+          dressCode={invitation.dressCode}
+          mapUrl={invitation.mapUrl}
+          venue={invitation.venue}
+        />
+        <SectionGaleri gallery={invitation.gallery} />
+        <SectionUcapan stats={invitation.stats} messages={invitation.messages} />
+      </main>
+      <Tabbar />
+      <div
+        data-modal="gallery"
+        className="modal fade show"
+        aria-hidden="true"
+        hidden
+        tabIndex={-1}
+        role="dialog"
+      >
+        <div className="d-flex justify-content-center align-items-center position-fixed top-0 start-0 w-100 h-100 bg-overlay-auto">
+          <div className="position-relative p-3 bg-white-black rounded-4 shadow-lg">
+            <button
+              type="button"
+              className="btn btn-outline-auto btn-sm rounded-pill position-absolute top-0 end-0 m-3"
+              data-modal-close
+            >
+              Tutup
+            </button>
+            <img src="" alt="" className="rounded-4 shadow" width={320} height={320} />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/legacy/BootstrapThemeClient.tsx
+++ b/components/legacy/BootstrapThemeClient.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export function BootstrapThemeClient({ theme = 'dark' }: { theme?: 'auto' | 'dark' | 'light' }) {
+  useEffect(() => {
+    const html = document.documentElement;
+    const previous = html.getAttribute('data-bs-theme');
+    if (previous === theme) {
+      return;
+    }
+    html.setAttribute('data-bs-theme', theme);
+    return () => {
+      if (previous) {
+        html.setAttribute('data-bs-theme', previous);
+      } else {
+        html.removeAttribute('data-bs-theme');
+      }
+    };
+  }, [theme]);
+
+  return null;
+}

--- a/components/legacy/Hero.tsx
+++ b/components/legacy/Hero.tsx
@@ -1,0 +1,62 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import type { InvitationHero } from '@/lib/types';
+import { CalendarIcon } from './Icon/CalendarIcon';
+
+export function Hero({ hero }: { hero: InvitationHero }) {
+  return (
+    <section
+      id="home"
+      data-section-id="home"
+      className="bg-light-dark position-relative overflow-hidden p-0 m-0"
+      style={{ minHeight: '100vh' }}
+    >
+      <Image
+        src={hero.backgroundImage}
+        alt={hero.backgroundAlt}
+        fill
+        sizes="100vw"
+        className="position-absolute opacity-25 top-50 start-50 translate-middle bg-cover-home"
+        priority
+      />
+      <div className="position-relative text-center bg-overlay-auto" style={{ backgroundColor: 'unset' }}>
+        <h1 className="font-esthetic pt-5 pb-4 fw-medium" style={{ fontSize: '2.25rem' }}>
+          Undangan Pernikahan
+        </h1>
+        <Image
+          src={hero.avatarImage}
+          alt={hero.avatarAlt}
+          width={208}
+          height={208}
+          className="img-center-crop rounded-circle border border-3 border-light shadow my-4 mx-auto cursor-pointer"
+          data-gallery-image
+          data-full={hero.avatarImage}
+        />
+        <h2 className="font-esthetic my-4" style={{ fontSize: '2.25rem' }}>
+          {hero.title}
+        </h2>
+        <p className="my-2" style={{ fontSize: '1.25rem' }}>
+          {hero.subtitle}
+        </p>
+        <Link
+          href={hero.googleCalendarUrl}
+          className="btn btn-outline-auto btn-sm shadow rounded-pill px-3 py-1 d-inline-flex align-items-center justify-content-center gap-2"
+          style={{ fontSize: '0.825rem' }}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <CalendarIcon width={16} height={16} />
+          <span>Save Google Calendar</span>
+        </Link>
+        <div className="d-flex justify-content-center align-items-center mt-4 mb-2">
+          <div className="mouse-animation border border-secondary border-2 rounded-5 px-2 py-1 opacity-50">
+            <div className="scroll-animation rounded-4 bg-secondary" />
+          </div>
+        </div>
+        <p className="pb-4 m-0 text-secondary" style={{ fontSize: '0.825rem' }}>
+          Scroll Down
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/components/legacy/Icon/CalendarIcon.tsx
+++ b/components/legacy/Icon/CalendarIcon.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from 'react';
+
+export function CalendarIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 0 1 2 0v1h1.5A2.5 2.5 0 0 1 22 6.5v13A2.5 2.5 0 0 1 19.5 22h-15A2.5 2.5 0 0 1 2 19.5v-13A2.5 2.5 0 0 1 4.5 4H6V3a1 1 0 0 1 1-1zm12.5 8.5h-15v9a.5.5 0 0 0 .5.5h14a.5.5 0 0 0 .5-.5zm-15-2h15V6.5a.5.5 0 0 0-.5-.5h-14a.5.5 0 0 0-.5.5z" />
+    </svg>
+  );
+}

--- a/components/legacy/Icon/GalleryIcon.tsx
+++ b/components/legacy/Icon/GalleryIcon.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from 'react';
+
+export function GalleryIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path d="M4.5 5h15A2.5 2.5 0 0 1 22 7.5v9A2.5 2.5 0 0 1 19.5 19h-15A2.5 2.5 0 0 1 2 16.5v-9A2.5 2.5 0 0 1 4.5 5zm0 2a.5.5 0 0 0-.5.5v9c0 .28.22.5.5.5h15a.5.5 0 0 0 .5-.5v-9a.5.5 0 0 0-.5-.5zm2.75 1.5a1.75 1.75 0 1 1 0 3.5 1.75 1.75 0 0 1 0-3.5zm2.21 7.25 2.57-3.21a1 1 0 0 1 1.56 0l1.55 1.94.49-.49a1 1 0 0 1 1.41 0l1.46 1.45z" />
+    </svg>
+  );
+}

--- a/components/legacy/Icon/HeartIcon.tsx
+++ b/components/legacy/Icon/HeartIcon.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from 'react';
+
+export function HeartIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path d="M12 21.35c-1.45-1.32-5.59-4.42-7.64-6.64C2.17 12.38 1.5 10.87 1.5 9.2c0-2.9 2.1-5.2 4.84-5.2 1.7 0 3.22.9 4.16 2.29.94-1.4 2.46-2.29 4.16-2.29 2.74 0 4.84 2.3 4.84 5.2 0 1.67-.67 3.18-2.86 5.51-2.05 2.22-6.19 5.32-7.64 6.64z" />
+    </svg>
+  );
+}

--- a/components/legacy/Icon/HomeIcon.tsx
+++ b/components/legacy/Icon/HomeIcon.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from 'react';
+
+export function HomeIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path d="M11.245 2.32a1.5 1.5 0 0 1 1.51 0l8.5 5a1.5 1.5 0 0 1 .745 1.3V20a2 2 0 0 1-2 2h-4.5a1.5 1.5 0 0 1-1.5-1.5V17a1.5 1.5 0 0 0-3 0v3.5a1.5 1.5 0 0 1-1.5 1.5H4a2 2 0 0 1-2-2V8.62a1.5 1.5 0 0 1 .745-1.3z" />
+    </svg>
+  );
+}

--- a/components/legacy/Icon/MessageIcon.tsx
+++ b/components/legacy/Icon/MessageIcon.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from 'react';
+
+export function MessageIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path d="M5 4h14a3 3 0 0 1 3 3v7a3 3 0 0 1-3 3h-4.38l-3.72 3.72A1 1 0 0 1 9 19.99V17H5a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h5a1 1 0 0 1 1 1v1.59l2.3-2.3a1 1 0 0 1 .7-.29H19a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1z" />
+    </svg>
+  );
+}

--- a/components/legacy/SectionGaleri.tsx
+++ b/components/legacy/SectionGaleri.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image';
+import type { InvitationGalleryItem } from '@/lib/types';
+
+export function SectionGaleri({ gallery }: { gallery: InvitationGalleryItem[] }) {
+  return (
+    <section className="bg-white-black pb-5 pt-3" id="galeri" data-section-id="galeri">
+      <div className="container">
+        <div className="border rounded-5 shadow p-3">
+          <h2 className="font-esthetic text-center py-2 m-0" style={{ fontSize: '2.25rem' }}>
+            Galeri Momen
+          </h2>
+          <div className="row g-3 mt-3">
+            {gallery.map((item) => (
+              <div key={item.src} className="col-6">
+                <Image
+                  src={item.src}
+                  alt={item.alt}
+                  width={item.width ?? 400}
+                  height={item.height ?? 400}
+                  className="w-100 h-100 rounded-4 shadow-sm cursor-pointer"
+                  style={{ objectFit: 'cover' }}
+                  data-gallery-image
+                  data-full={item.src}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/legacy/SectionMempelai.tsx
+++ b/components/legacy/SectionMempelai.tsx
@@ -1,0 +1,73 @@
+import Image from 'next/image';
+import type { InvitationCouple } from '@/lib/types';
+
+export function SectionMempelai({ couple }: { couple: InvitationCouple }) {
+  return (
+    <section className="bg-white-black text-center" id="mempelai" data-section-id="mempelai">
+      <div className="container py-5">
+        <h2 className="font-arabic py-2 m-0" style={{ fontSize: '2rem' }}>
+          بِسْمِ اللّٰهِ الرَّحْمٰنِ الرَّحِيْمِ
+        </h2>
+        <h2 className="font-esthetic py-4 m-0" style={{ fontSize: '2rem' }}>
+          Assalamualaikum Warahmatullahi Wabarakatuh
+        </h2>
+        <p className="pb-4 px-2 m-0" style={{ fontSize: '0.95rem' }}>
+          Tanpa mengurangi rasa hormat, kami mengundang Anda untuk berkenan menghadiri acara pernikahan kami:
+        </p>
+        <div className="overflow-x-hidden pb-4">
+          <div className="position-relative">
+            <div className="pb-1">
+              <Image
+                src={couple.groom.image}
+                alt={couple.groom.name}
+                width={208}
+                height={208}
+                className="img-center-crop rounded-circle border border-3 border-light shadow my-4 mx-auto cursor-pointer"
+                data-gallery-image
+                data-full={couple.groom.image}
+              />
+              <h3 className="font-esthetic m-0" style={{ fontSize: '2.125rem' }}>
+                {couple.groom.name}
+              </h3>
+              <p className="mt-3 mb-1" style={{ fontSize: '1.25rem' }}>
+                {couple.groom.role}
+              </p>
+              {couple.groom.parents.map((parent) => (
+                <p key={parent} className="mb-0" style={{ fontSize: '0.95rem' }}>
+                  {parent}
+                </p>
+              ))}
+            </div>
+          </div>
+          <h2 className="font-esthetic mt-4" style={{ fontSize: '4.5rem' }}>
+            &
+          </h2>
+          <div className="position-relative">
+            <div className="pb-1">
+              <Image
+                src={couple.bride.image}
+                alt={couple.bride.name}
+                width={208}
+                height={208}
+                className="img-center-crop rounded-circle border border-3 border-light shadow my-4 mx-auto cursor-pointer"
+                data-gallery-image
+                data-full={couple.bride.image}
+              />
+              <h3 className="font-esthetic m-0" style={{ fontSize: '2.125rem' }}>
+                {couple.bride.name}
+              </h3>
+              <p className="mt-3 mb-1" style={{ fontSize: '1.25rem' }}>
+                {couple.bride.role}
+              </p>
+              {couple.bride.parents.map((parent) => (
+                <p key={parent} className="mb-0" style={{ fontSize: '0.95rem' }}>
+                  {parent}
+                </p>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/legacy/SectionTanggal.tsx
+++ b/components/legacy/SectionTanggal.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import type { InvitationSchedule } from '@/lib/types';
+
+interface Props {
+  schedules: InvitationSchedule[];
+  headline: string;
+  description: string;
+  dressCode: string;
+  mapUrl: string;
+  venue: string;
+}
+
+interface Countdown {
+  days: string;
+  hours: string;
+  minutes: string;
+  seconds: string;
+}
+
+const pad = (value: number) => value.toString().padStart(2, '0');
+
+export function SectionTanggal({
+  schedules,
+  headline,
+  description,
+  dressCode,
+  mapUrl,
+  venue,
+}: Props) {
+  const targetDate = useMemo(() => new Date(schedules[0]?.start ?? Date.now()), [schedules]);
+  const [countdown, setCountdown] = useState<Countdown>(() => ({
+    days: '00',
+    hours: '00',
+    minutes: '00',
+    seconds: '00',
+  }));
+
+  useEffect(() => {
+    const tick = () => {
+      const diff = Math.max(0, targetDate.getTime() - Date.now());
+      const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+      const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+      const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+      const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+      setCountdown({
+        days: pad(days),
+        hours: pad(hours),
+        minutes: pad(minutes),
+        seconds: pad(seconds),
+      });
+    };
+
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => window.clearInterval(id);
+  }, [targetDate]);
+
+  return (
+    <section className="bg-white-black pb-5" id="tanggal" data-section-id="tanggal">
+      <div className="container text-center py-5">
+        <h2 className="font-esthetic py-4 m-0" style={{ fontSize: '2.25rem' }}>
+          {headline}
+        </h2>
+        <div className="border rounded-pill shadow py-2 px-4 mt-2 mb-4">
+          <div className="row justify-content-center">
+            <div className="col-3 p-1">
+              <p className="d-inline m-0 p-0" style={{ fontSize: '1.25rem' }}>
+                {countdown.days}
+              </p>
+              <small className="ms-1">Hari</small>
+            </div>
+            <div className="col-3 p-1">
+              <p className="d-inline m-0 p-0" style={{ fontSize: '1.25rem' }}>
+                {countdown.hours}
+              </p>
+              <small className="ms-1">Jam</small>
+            </div>
+            <div className="col-3 p-1">
+              <p className="d-inline m-0 p-0" style={{ fontSize: '1.25rem' }}>
+                {countdown.minutes}
+              </p>
+              <small className="ms-1">Menit</small>
+            </div>
+            <div className="col-3 p-1">
+              <p className="d-inline m-0 p-0" style={{ fontSize: '1.25rem' }}>
+                {countdown.seconds}
+              </p>
+              <small className="ms-1">Detik</small>
+            </div>
+          </div>
+        </div>
+        <p className="py-2 m-0" style={{ fontSize: '0.95rem' }}>
+          {description}
+        </p>
+        <div className="overflow-x-hidden">
+          {schedules.map((schedule) => (
+            <div key={schedule.title} className="py-3" style={{ fontSize: '0.95rem' }}>
+              <h3 className="font-esthetic m-0 py-2" style={{ fontSize: '2rem' }}>
+                {schedule.title}
+              </h3>
+              <p className="m-0">{schedule.timeLabel}</p>
+            </div>
+          ))}
+        </div>
+        <p className="py-2 m-0" style={{ fontSize: '0.95rem' }}>
+          Demi kehangatan bersama, kami memohon kesediaan Anda untuk mengenakan dress code berikut:
+        </p>
+        <div className="py-2">
+          <div className="d-flex justify-content-center align-items-center mb-3">
+            <div className="shadow rounded-circle border border-secondary" style={{ width: '3rem', height: '3rem', backgroundColor: 'white' }} />
+            <div className="shadow rounded-circle border border-secondary" style={{ width: '3rem', height: '3rem', backgroundColor: 'aquamarine', marginLeft: '-1rem' }} />
+            <div className="shadow rounded-circle border border-secondary" style={{ width: '3rem', height: '3rem', backgroundColor: 'limegreen', marginLeft: '-1rem' }} />
+          </div>
+          <p style={{ fontSize: '0.95rem' }}>{dressCode}</p>
+        </div>
+        <div className="py-2">
+          <Link
+            href={mapUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="btn btn-outline-auto btn-sm rounded-pill shadow mb-2 px-3"
+          >
+            Lihat Google Maps
+          </Link>
+          <small className="d-block my-1">{venue}</small>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/legacy/SectionUcapan.tsx
+++ b/components/legacy/SectionUcapan.tsx
@@ -1,0 +1,88 @@
+import type { InvitationMessage, InvitationStats } from '@/lib/types';
+import { StatsCards } from './StatsCards';
+
+interface Props {
+  stats: InvitationStats;
+  messages: InvitationMessage[];
+}
+
+export function SectionUcapan({ stats, messages }: Props) {
+  return (
+    <section className="bg-light-dark py-5" id="ucapan" data-section-id="ucapan">
+      <div className="container">
+        <div className="bg-theme-auto rounded-5 shadow p-4">
+          <h2 className="font-esthetic text-center mb-4" style={{ fontSize: '2.25rem' }}>
+            Ucapan &amp; Doa
+          </h2>
+          <StatsCards stats={stats} />
+          <div className="mt-4">
+            <h3 className="font-esthetic text-center mb-3" style={{ fontSize: '2rem' }}>
+              Kirim Ucapan
+            </h3>
+            <form className="row g-3" data-ucapan-form>
+              <div className="col-12">
+                <label htmlFor="nama" className="form-label fw-semibold">
+                  Nama
+                </label>
+                <input
+                  id="nama"
+                  name="nama"
+                  className="form-control"
+                  placeholder="Nama lengkap"
+                  required
+                />
+              </div>
+              <div className="col-12">
+                <label htmlFor="pesan" className="form-label fw-semibold">
+                  Pesan
+                </label>
+                <textarea
+                  id="pesan"
+                  name="pesan"
+                  className="form-control"
+                  placeholder="Tulis ucapan terbaikmu di sini"
+                  rows={3}
+                  required
+                />
+              </div>
+              <div className="col-12 d-flex justify-content-between align-items-center">
+                <button type="submit" className="btn btn-outline-auto rounded-pill px-4">
+                  Kirim Ucapan
+                </button>
+                <p
+                  className="m-0 small text-secondary"
+                  data-form-status
+                  role="status"
+                  aria-live="polite"
+                />
+              </div>
+            </form>
+          </div>
+          <div className="mt-5">
+            <h3 className="font-esthetic text-center mb-3" style={{ fontSize: '2rem' }}>
+              Ucapan Teman &amp; Keluarga
+            </h3>
+            <div className="list-group list-group-flush">
+              {messages.map((message) => (
+                <div key={message.id} className="list-group-item bg-transparent border-secondary-subtle border rounded-4 mb-3 p-3">
+                  <div className="d-flex justify-content-between align-items-center mb-2">
+                    <h4 className="m-0" style={{ fontSize: '1rem' }}>
+                      {message.name}
+                    </h4>
+                    <span className="badge bg-theme-auto text-uppercase" style={{ fontSize: '0.65rem' }}>
+                      {message.status}
+                    </span>
+                  </div>
+                  <p className="mb-2" style={{ fontSize: '0.95rem' }}>
+                    {message.message}
+                  </p>
+                  <small className="text-secondary">{message.createdAt}</small>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/legacy/StatsCards.tsx
+++ b/components/legacy/StatsCards.tsx
@@ -1,0 +1,27 @@
+import type { InvitationStats } from '@/lib/types';
+
+export function StatsCards({ stats }: { stats: InvitationStats }) {
+  const items = [
+    { label: 'Comments', value: stats.comments },
+    { label: 'Present', value: stats.present },
+    { label: 'Absent', value: stats.absent },
+    { label: 'Likes', value: stats.likes },
+  ];
+
+  return (
+    <div className="row g-3">
+      {items.map((item) => (
+        <div key={item.label} className="col-6">
+          <div className="bg-theme-auto text-center rounded-4 shadow-sm p-3 h-100">
+            <p className="m-0" style={{ fontSize: '2rem' }}>
+              {item.value.toLocaleString('id-ID')}
+            </p>
+            <p className="m-0 text-uppercase" style={{ fontSize: '0.75rem', letterSpacing: '0.08em' }}>
+              {item.label}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/legacy/Tabbar.tsx
+++ b/components/legacy/Tabbar.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+import { CalendarIcon } from './Icon/CalendarIcon';
+import { GalleryIcon } from './Icon/GalleryIcon';
+import { HeartIcon } from './Icon/HeartIcon';
+import { HomeIcon } from './Icon/HomeIcon';
+import { MessageIcon } from './Icon/MessageIcon';
+
+const items = [
+  { id: 'home', label: 'Beranda', Icon: HomeIcon },
+  { id: 'mempelai', label: 'Mempelai', Icon: HeartIcon },
+  { id: 'tanggal', label: 'Tanggal & Lokasi', Icon: CalendarIcon },
+  { id: 'galeri', label: 'Galeri', Icon: GalleryIcon },
+  { id: 'ucapan', label: 'Ucapan', Icon: MessageIcon },
+] as const;
+
+export function Tabbar() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const first = document.querySelector<HTMLAnchorElement>(
+      '#undangan4x [data-tab-target="home"]'
+    );
+    if (first && !document.querySelector('#undangan4x [data-tab-target].active')) {
+      first.classList.add('active');
+    }
+  }, [pathname]);
+
+  return (
+    <nav
+      id="navbar-menu"
+      className="position-fixed bottom-0 start-50 translate-middle-x w-100 px-3 pb-3"
+      aria-label="Navigasi undangan"
+    >
+      <ul className="nav nav-pills bg-overlay-auto shadow rounded-4 justify-content-around py-2">
+        {items.map(({ id, label, Icon }) => (
+          <li key={id} className="nav-item">
+            <Link
+              href={`#${id}`}
+              className="nav-link text-center d-flex flex-column align-items-center gap-1 px-2"
+              data-tab-target={id}
+              scroll={false}
+            >
+              <Icon className="tab-icon" width={20} height={20} />
+              <span className="small">{label}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/lib/gcal.ts
+++ b/lib/gcal.ts
@@ -1,28 +1,23 @@
-import { getSiteUrl } from './getSiteUrl';
-
-function normalizeIso(iso: string) {
-  return iso.replace(/[-:]/g, '').replace(/\.\d{3}/, '');
-}
+const formatDate = (value: string) => {
+  const date = new Date(value);
+  const iso = date.toISOString().replace(/[-:]/g, '');
+  return iso.slice(0, 15) + 'Z';
+};
 
 export function gcalEventUrl(
   title: string,
   startISO: string,
   endISO: string,
   location: string,
-  detailsUrl?: string
+  detailsUrl: string
 ) {
-  const params = new URLSearchParams();
-  params.set('action', 'TEMPLATE');
-  params.set('text', title);
-  params.set('dates', `${normalizeIso(startISO)}/${normalizeIso(endISO)}`);
-  if (location) {
-    params.set('location', location);
-  }
-  const fallback = getSiteUrl();
-  const details = detailsUrl
-    ? `${detailsUrl}\n\nTerima kasih telah berbagi kebahagiaan bersama kami.`
-    : fallback;
-  params.set('details', details);
-  params.set('trp', 'false');
-  return `https://www.google.com/calendar/render?${params.toString()}`;
+  const base = 'https://calendar.google.com/calendar/render';
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: title,
+    dates: `${formatDate(startISO)}/${formatDate(endISO)}`,
+    location,
+    details: detailsUrl,
+  });
+  return `${base}?${params.toString()}`;
 }

--- a/lib/getSiteUrl.ts
+++ b/lib/getSiteUrl.ts
@@ -1,5 +1,9 @@
 export function getSiteUrl() {
-  if (process.env.NEXT_PUBLIC_SITE_URL) return process.env.NEXT_PUBLIC_SITE_URL;
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-  return 'http://localhost:3000';
+  if (typeof window !== 'undefined') {
+    return window.location.origin;
+  }
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,48 +1,65 @@
-export type Couple = {
-  panggilanPria: string;
-  namaPria: string;
-  panggilanWanita: string;
-  namaWanita: string;
-  fotoCoverUrl?: string;
-  fotoPriaUrl?: string;
-  fotoWanitaUrl?: string;
-};
+export interface InvitationHero {
+  title: string;
+  subtitle: string;
+  backgroundImage: string;
+  backgroundAlt: string;
+  avatarImage: string;
+  avatarAlt: string;
+  googleCalendarUrl: string;
+}
 
-export type EventItem = {
-  label: string;
-  tanggal: string; // ISO Date string (YYYY-MM-DD)
-  jamMulai: string; // HH:mm
-  jamSelesai: string; // HH:mm
-  alamat: string;
-  gmapsUrl?: string;
-};
+export interface InvitationPerson {
+  name: string;
+  role: string;
+  parents: string[];
+  image: string;
+}
 
-export type Stats = {
+export interface InvitationCouple {
+  groom: InvitationPerson;
+  bride: InvitationPerson;
+}
+
+export interface InvitationSchedule {
+  title: string;
+  start: string;
+  end: string;
+  timeLabel: string;
+}
+
+export interface InvitationGalleryItem {
+  src: string;
+  alt: string;
+  width?: number;
+  height?: number;
+}
+
+export interface InvitationMessage {
+  id: string;
+  name: string;
+  message: string;
+  status: string;
+  createdAt: string;
+}
+
+export interface InvitationStats {
   comments: number;
   present: number;
   absent: number;
   likes: number;
-};
+}
 
-export type Comment = {
-  id: string;
-  nama: string;
-  pesan: string;
-  waktuISO: string;
-  presence?: 'present' | 'absent' | 'unknown';
-  likes?: number;
-};
-
-export type Parents = {
-  pria: string;
-  wanita: string;
-};
-
-export type InvitationContent = {
-  couple: Couple;
-  events: EventItem[];
-  stats: Stats;
-  comments: Comment[];
-  gallery: string[];
-  orangTua: Parents;
-};
+export interface InvitationContent {
+  slug: string;
+  hero: InvitationHero;
+  couple: InvitationCouple;
+  schedules: InvitationSchedule[];
+  headline: string;
+  description: string;
+  dressCode: string;
+  mapUrl: string;
+  venue: string;
+  gallery: InvitationGalleryItem[];
+  messages: InvitationMessage[];
+  stats: InvitationStats;
+}

--- a/public/themes/undangan-4x/css/undangan4x.css
+++ b/public/themes/undangan-4x/css/undangan4x.css
@@ -1,0 +1,291 @@
+@keyframes scroll {
+    0% {
+        transform: translateY(1rem);
+        opacity: 0;
+    }
+
+    10% {
+        transform: translateY(0);
+        opacity: 1;
+    }
+
+    100% {
+        transform: translateY(0);
+        opacity: 0;
+    }
+}
+
+.mouse-animation>.scroll-animation {
+    width: 0.25rem;
+    height: 0.625rem;
+    animation: scroll 3s linear infinite;
+}
+
+.mouse-animation {
+    height: 2rem;
+    box-sizing: content-box;
+}
+
+@keyframes spin-icon {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.spin-button {
+    animation: spin-icon 5s linear infinite;
+}
+
+@keyframes love {
+    50% {
+        transform: translateY(1rem);
+    }
+}
+
+.animate-love {
+    animation: love 5s ease-in-out infinite;
+}
+
+.slide-desktop {
+    transform: scale(1);
+    transition: transform 10s linear;
+}
+
+.slide-desktop-active {
+    transform: scale(1.15);
+}html {
+    scroll-behavior: smooth !important;
+    width: 100vw !important;
+}
+
+body {
+    font-family: 'Josefin Sans', sans-serif !important;
+    padding: 0 !important;
+    width: 100% !important;
+    overflow-x: hidden !important;
+}
+
+i {
+    width: auto !important;
+}
+
+body,
+div,
+nav,
+svg,
+section {
+    will-change: background-color;
+    transition: background-color 350ms ease;
+}
+
+svg>path {
+    will-change: color;
+    transition: color 350ms ease;
+}
+
+html[data-bs-theme="dark"] .navbar {
+    background-color: rgba(var(--bs-dark-rgb), 0.75) !important;
+    backdrop-filter: blur(0.5rem);
+}
+
+html[data-bs-theme="light"] .navbar {
+    background-color: rgba(var(--bs-light-rgb), 0.75) !important;
+    backdrop-filter: blur(0.5rem);
+}
+
+html[data-bs-theme="dark"] .text-theme-auto {
+    color: rgb(var(--bs-light-rgb));
+}
+
+html[data-bs-theme="light"] .text-theme-auto {
+    color: rgb(var(--bs-dark-rgb));
+}
+
+html[data-bs-theme="dark"] .nav-link {
+    color: rgba(var(--bs-white-rgb), 0.5);
+}
+
+html[data-bs-theme="light"] .nav-link {
+    color: rgba(var(--bs-black-rgb), 0.5);
+}
+
+html[data-bs-theme="dark"] .bg-theme-auto {
+    background-color: var(--bs-gray-800);
+}
+
+html[data-bs-theme="light"] .bg-theme-auto {
+    background-color: var(--bs-gray-100);
+}
+
+html[data-bs-theme="dark"] .btn-outline-auto {
+    --bs-btn-color: var(--bs-light);
+    --bs-btn-border-color: var(--bs-light);
+    --bs-btn-hover-color: var(--bs-black);
+    --bs-btn-hover-bg: var(--bs-light);
+    --bs-btn-hover-border-color: var(--bs-light);
+    --bs-btn-focus-shadow-rgb: var(--bs-light-rgb);
+    --bs-btn-active-color: var(--bs-black);
+    --bs-btn-active-bg: var(--bs-light);
+    --bs-btn-active-border-color: var(--bs-light);
+    --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+    --bs-btn-disabled-color: var(--bs-light);
+    --bs-btn-disabled-bg: transparent;
+    --bs-btn-disabled-border-color: var(--bs-light);
+    --bs-gradient: none;
+}
+
+html[data-bs-theme="light"] .btn-outline-auto {
+    --bs-btn-color: var(--bs-dark);
+    --bs-btn-border-color: var(--bs-dark);
+    --bs-btn-hover-color: var(--bs-white);
+    --bs-btn-hover-bg: var(--bs-dark);
+    --bs-btn-hover-border-color: var(--bs-dark);
+    --bs-btn-focus-shadow-rgb: var(--bs-dark-rgb);
+    --bs-btn-active-color: var(--bs-white);
+    --bs-btn-active-bg: var(--bs-dark);
+    --bs-btn-active-border-color: var(--bs-dark);
+    --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+    --bs-btn-disabled-color: var(--bs-dark);
+    --bs-btn-disabled-bg: transparent;
+    --bs-btn-disabled-border-color: var(--bs-dark);
+    --bs-gradient: none;
+}
+
+html[data-bs-theme="dark"] .bg-overlay-auto {
+    background-color: rgba(var(--bs-black-rgb), 0.5);
+    backdrop-filter: blur(0.25rem);
+}
+
+html[data-bs-theme="light"] .bg-overlay-auto {
+    background-color: rgba(var(--bs-white-rgb), 0.5);
+    backdrop-filter: blur(0.25rem);
+}
+
+.hover-area {
+    display: none;
+    cursor: pointer;
+}
+
+.hover-wrapper:hover .hover-area {
+    display: flex;
+}
+
+.gif-image {
+    max-height: 10rem;
+}@import url("common.css");
+html {
+    scrollbar-width: none !important;
+    -ms-overflow-style: none !important;
+}
+
+.with-scrollbar {
+    scrollbar-width: auto !important;
+    -ms-overflow-style: auto !important;
+}
+
+.font-esthetic {
+    font-family: 'Sacramento', cursive !important;
+}
+
+.font-arabic {
+    font-family: 'Noto Naskh Arabic', serif !important;
+}
+
+.img-center-crop {
+    width: 13rem;
+    height: 13rem;
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: cover;
+}
+
+html[data-bs-theme="dark"] .btn-transparent {
+    background-color: rgba(var(--bs-dark-rgb), 0.5) !important;
+    backdrop-filter: blur(0.5rem);
+}
+
+html[data-bs-theme="light"] .btn-transparent {
+    background-color: rgba(var(--bs-light-rgb), 0.5) !important;
+    backdrop-filter: blur(0.5rem);
+}
+
+.loading-page {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1056;
+}
+
+html[data-bs-theme="light"] .color-theme-svg {
+    color: rgb(255, 255, 255);
+    background-color: var(--bs-light);
+}
+
+html[data-bs-theme="dark"] .color-theme-svg {
+    color: rgb(0, 0, 0);
+    background-color: var(--bs-dark);
+}
+
+html[data-bs-theme="light"] .bg-light-dark {
+    background-color: rgb(var(--bs-light-rgb));
+}
+
+html[data-bs-theme="dark"] .bg-light-dark {
+    background-color: rgb(var(--bs-dark-rgb));
+}
+
+html[data-bs-theme="light"] .bg-white-black {
+    background-color: rgb(var(--bs-white-rgb));
+}
+
+html[data-bs-theme="dark"] .bg-white-black {
+    background-color: rgb(var(--bs-black-rgb));
+}
+
+.bg-cover-home {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    mask-image: linear-gradient(0.5turn, transparent, black 40%, black 60%, transparent);
+}
+
+.width-loading {
+    width: 25%;
+}
+
+.cursor-pointer {
+    cursor: pointer;
+}
+
+@media screen and (max-width: 992px) {
+    .width-loading {
+        width: 50%;
+    }
+}
+
+@media screen and (max-width: 576px) {
+    .width-loading {
+        width: 75%;
+    }
+}
+
+svg {
+    display: block;
+    line-height: 0;
+    shape-rendering: geometricPrecision;
+    backface-visibility: hidden;
+}
+
+.svg-wrapper {
+    overflow: hidden !important;
+    transform: translateZ(0) !important;
+}
+
+.no-gap-bottom {
+    margin-bottom: -0.75rem !important;
+}

--- a/public/themes/undangan-4x/js/guest.js
+++ b/public/themes/undangan-4x/js/guest.js
@@ -1,0 +1,138 @@
+(function () {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const ready = (fn) => {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn, { once: true });
+    } else {
+      fn();
+    }
+  };
+
+  ready(() => {
+    const root = document.getElementById('undangan4x');
+    if (!root) {
+      return;
+    }
+
+    const tabButtons = Array.from(root.querySelectorAll('[data-tab-target]'));
+    const sections = Array.from(root.querySelectorAll('[data-section-id]'));
+
+    const activateTab = (id) => {
+      tabButtons.forEach((button) => {
+        const target = button.getAttribute('data-tab-target');
+        if (!target) return;
+        if (target === id) {
+          button.classList.add('active');
+          button.setAttribute('aria-current', 'page');
+        } else {
+          button.classList.remove('active');
+          button.removeAttribute('aria-current');
+        }
+      });
+    };
+
+    tabButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        const id = button.getAttribute('data-tab-target');
+        if (!id) return;
+        const target = root.querySelector(`[data-section-id="${CSS.escape(id)}"]`);
+        if (!target) return;
+        event.preventDefault();
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        activateTab(id);
+      });
+    });
+
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              const id = entry.target.getAttribute('data-section-id');
+              if (id) {
+                activateTab(id);
+              }
+            }
+          });
+        },
+        { rootMargin: '-40% 0px -40% 0px', threshold: 0.25 }
+      );
+      sections.forEach((section) => observer.observe(section));
+    }
+
+    const modal = root.querySelector('[data-modal="gallery"]');
+    const modalImage = modal ? modal.querySelector('img') : null;
+    const closeModal = () => {
+      if (!modal) return;
+      modal.classList.remove('open');
+      modal.setAttribute('aria-hidden', 'true');
+      modal.setAttribute('hidden', '');
+      modalImage && (modalImage.src = '');
+    };
+
+    if (modal) {
+      modal.addEventListener('click', (event) => {
+        if (event.target === modal || event.target.hasAttribute('data-modal-close')) {
+          closeModal();
+        }
+      });
+      modal.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeModal();
+        }
+      });
+    }
+
+    root.querySelectorAll('[data-gallery-image]').forEach((element) => {
+      element.addEventListener('click', () => {
+        if (!modal || !modalImage) return;
+        const fullSrc = element.getAttribute('data-full') || element.getAttribute('src');
+        if (!fullSrc) return;
+        modalImage.src = fullSrc;
+        modalImage.alt = element.getAttribute('alt') || '';
+        modal.removeAttribute('hidden');
+        modal.classList.add('open');
+        modal.setAttribute('aria-hidden', 'false');
+        modal.focus({ preventScroll: true });
+      });
+    });
+
+    const form = root.querySelector('form[data-ucapan-form]');
+    const statusEl = form ? form.querySelector('[data-form-status]') : null;
+    if (form) {
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!statusEl) return;
+        statusEl.textContent = 'Mengirim...';
+        statusEl.dataset.state = 'loading';
+        const formData = new FormData(form);
+        const payload = {
+          nama: formData.get('nama')?.toString().trim() ?? '',
+          pesan: formData.get('pesan')?.toString().trim() ?? '',
+        };
+
+        try {
+          const response = await fetch('/api/ucapan', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          const result = await response.json();
+          if (response.ok && result?.ok) {
+            statusEl.textContent = 'Terima kasih! Ucapanmu sudah kami terima.';
+            statusEl.dataset.state = 'success';
+            form.reset();
+          } else {
+            throw new Error('Gagal mengirim ucapan');
+          }
+        } catch (error) {
+          statusEl.textContent = 'Maaf, terjadi kesalahan. Coba lagi nanti.';
+          statusEl.dataset.state = 'error';
+        }
+      });
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add the `/undangan/[slug]` app router entry with the Rahmat & Nisa demo content
- port the undangan-4.x legacy components, styles, and script into an isolated invitation layout
- provide supporting helpers and an `/api/ucapan` stub for comment submission

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68e5c6f18cf88324b2e55484dcbb8e3a