### PR TITLE
Fix missing Comment type definition for comment components

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -42,6 +42,13 @@ export interface InvitationMessage {
   createdAt: string;
 }
 
+export interface Comment {
+  id: string;
+  nama: string;
+  pesan: string;
+  waktuISO: string;
+}
+
 export interface InvitationStats {
   comments: number;
   present: number;


### PR DESCRIPTION
## Summary
- add the `Comment` interface to `lib/types` so comment components can import it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5cd1a60bc8324813414615b97647c