### PR TITLE
Define shared types for new invitation components

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -22,7 +22,8 @@ export function Hero({ couple, firstEvent }: HeroProps) {
     `${couple.panggilanPria} & ${couple.panggilanWanita}`,
     firstEventStart.toISOString(),
     firstEventEnd.toISOString(),
-    firstEvent.alamat
+    firstEvent.alamat,
+    firstEvent.detailUrl ?? ''
   );
   const eventDateLabel = formatIndonesianDate(firstEventStart);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -56,6 +56,8 @@ export interface InvitationStats {
   likes: number;
 }
 
+export type Stats = InvitationStats;
+
 export interface InvitationContent {
   slug: string;
   hero: InvitationHero;
@@ -69,4 +71,27 @@ export interface InvitationContent {
   gallery: InvitationGalleryItem[];
   messages: InvitationMessage[];
   stats: InvitationStats;
+}
+
+export interface Couple {
+  namaPria: string;
+  namaWanita: string;
+  panggilanPria: string;
+  panggilanWanita: string;
+  fotoCoverUrl?: string | null;
+}
+
+export interface Parents {
+  pria: string;
+  wanita: string;
+}
+
+export interface EventItem {
+  label: string;
+  tanggal: string;
+  jamMulai: string;
+  jamSelesai: string;
+  alamat: string;
+  detailUrl?: string | null;
+  gmapsUrl?: string | null;
 }


### PR DESCRIPTION
## Summary
- export the new Couple, Parents, EventItem, and Stats types from `lib/types`
- update the hero component to pass an optional detail URL when creating Google Calendar links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5ce1ec4448324867e16836d5828a5