### PR TITLE
Add scoped undangan 4.x theme layout for invitation route

### DIFF
--- a/app/undangan/[slug]/head.tsx
+++ b/app/undangan/[slug]/head.tsx
@@ -12,6 +12,7 @@ export default function InvitationHead() {
         href="https://fonts.googleapis.com/css2?family=Sacramento&family=Noto+Naskh+Arabic&display=swap"
       />
       <link rel="stylesheet" href="/themes/undangan-4x/css/undangan4x.css" />
+      <link rel="stylesheet" href="/themes/undangan-4x/css/undangan4x.scoped.css" />
     </>
   );
 }

--- a/app/undangan/[slug]/layout.tsx
+++ b/app/undangan/[slug]/layout.tsx
@@ -6,7 +6,9 @@ export default function InvitationLayout({ children }: { children: ReactNode }) 
   return (
     <>
       <BootstrapThemeClient theme="dark" />
-      {children}
+      <div id="undangan4x" className="u4x bg-white-black position-relative" data-section-id="root">
+        {children}
+      </div>
       <Script src="/themes/undangan-4x/js/guest.js" strategy="afterInteractive" />
     </>
   );

--- a/app/undangan/[slug]/page.tsx
+++ b/app/undangan/[slug]/page.tsx
@@ -21,7 +21,7 @@ export default function InvitationPage({ params }: PageProps) {
   }
 
   return (
-    <div id="undangan4x" className="u4x bg-white-black position-relative" data-section-id="root">
+    <>
       <main className="position-relative pb-5 mb-5" data-bs-spy="scroll" data-bs-target="#navbar-menu" data-bs-smooth-scroll="true">
         <Hero hero={invitation.hero} />
         <SectionMempelai couple={invitation.couple} />
@@ -58,6 +58,6 @@ export default function InvitationPage({ params }: PageProps) {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/components/legacy/Hero.tsx
+++ b/components/legacy/Hero.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import Link from 'next/link';
 import type { InvitationHero } from '@/lib/types';
 import { CalendarIcon } from './Icon/CalendarIcon';
 
@@ -38,7 +37,7 @@ export function Hero({ hero }: { hero: InvitationHero }) {
         <p className="my-2" style={{ fontSize: '1.25rem' }}>
           {hero.subtitle}
         </p>
-        <Link
+        <a
           href={hero.googleCalendarUrl}
           className="btn btn-outline-auto btn-sm shadow rounded-pill px-3 py-1 d-inline-flex align-items-center justify-content-center gap-2"
           style={{ fontSize: '0.825rem' }}
@@ -47,7 +46,7 @@ export function Hero({ hero }: { hero: InvitationHero }) {
         >
           <CalendarIcon width={16} height={16} />
           <span>Save Google Calendar</span>
-        </Link>
+        </a>
         <div className="d-flex justify-content-center align-items-center mt-4 mb-2">
           <div className="mouse-animation border border-secondary border-2 rounded-5 px-2 py-1 opacity-50">
             <div className="scroll-animation rounded-4 bg-secondary" />

--- a/components/legacy/SectionTanggal.tsx
+++ b/components/legacy/SectionTanggal.tsx
@@ -123,7 +123,7 @@ export function SectionTanggal({
             rel="noreferrer"
             className="btn btn-outline-auto btn-sm rounded-pill shadow mb-2 px-3"
           >
-            Lihat Google Maps
+            Buka Maps
           </Link>
           <small className="d-block my-1">{venue}</small>
         </div>

--- a/components/legacy/Tabbar.tsx
+++ b/components/legacy/Tabbar.tsx
@@ -32,20 +32,23 @@ export function Tabbar() {
   return (
     <nav
       id="navbar-menu"
-      className="position-fixed bottom-0 start-50 translate-middle-x w-100 px-3 pb-3"
+      className="navbar navbar-expand sticky-bottom rounded-top-4 border-top p-0"
       aria-label="Navigasi undangan"
     >
-      <ul className="nav nav-pills bg-overlay-auto shadow rounded-4 justify-content-around py-2">
+      <ul className="navbar-nav nav-justified w-100 align-items-center">
         {items.map(({ id, label, Icon }) => (
           <li key={id} className="nav-item">
             <Link
               href={`#${id}`}
-              className="nav-link text-center d-flex flex-column align-items-center gap-1 px-2"
+              className="nav-link text-center d-flex flex-column align-items-center py-2"
               data-tab-target={id}
               scroll={false}
+              prefetch={false}
             >
               <Icon className="tab-icon" width={20} height={20} />
-              <span className="small">{label}</span>
+              <span className="d-block" style={{ fontSize: '0.7rem' }}>
+                {label}
+              </span>
             </Link>
           </li>
         ))}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "jadiundangan-next",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.45.0",
@@ -29,6 +30,7 @@
         "eslint-config-next": "14.2.5",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.10",
+        "tsx": "^4.15.7",
         "typescript": "5.4.5"
       }
     },
@@ -77,6 +79,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2231,6 +2675,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/escalade": {
@@ -5802,6 +6288,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "prefix:undangan4x": "tsx scripts/prefix-undangan4x.ts",
+    "postinstall": "npm run prefix:undangan4x"
   },
   "dependencies": {
     "@supabase/ssr": "^0.7.0",
@@ -30,6 +32,7 @@
     "eslint-config-next": "14.2.5",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.10",
+    "tsx": "^4.15.7",
     "typescript": "5.4.5"
   }
 }

--- a/public/themes/undangan-4x/css/undangan4x.scoped.css
+++ b/public/themes/undangan-4x/css/undangan4x.scoped.css
@@ -1,0 +1,291 @@
+@keyframes scroll {
+    0% {
+        transform: translateY(1rem);
+        opacity: 0;
+    }
+
+    10% {
+        transform: translateY(0);
+        opacity: 1;
+    }
+
+    100% {
+        transform: translateY(0);
+        opacity: 0;
+    }
+}
+
+#undangan4x :where(.mouse-animation>.scroll-animation) {
+    width: 0.25rem;
+    height: 0.625rem;
+    animation: scroll 3s linear infinite;
+}
+
+#undangan4x :where(.mouse-animation) {
+    height: 2rem;
+    box-sizing: content-box;
+}
+
+@keyframes spin-icon {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+#undangan4x :where(.spin-button) {
+    animation: spin-icon 5s linear infinite;
+}
+
+@keyframes love {
+    50% {
+        transform: translateY(1rem);
+    }
+}
+
+#undangan4x :where(.animate-love) {
+    animation: love 5s ease-in-out infinite;
+}
+
+#undangan4x :where(.slide-desktop) {
+    transform: scale(1);
+    transition: transform 10s linear;
+}
+
+#undangan4x :where(.slide-desktop-active) {
+    transform: scale(1.15);
+}html #undangan4x {
+    scroll-behavior: smooth !important;
+    width: 100vw !important;
+}
+
+#undangan4x {
+    font-family: 'Josefin Sans', sans-serif !important;
+    padding: 0 !important;
+    width: 100% !important;
+    overflow-x: hidden !important;
+}
+
+#undangan4x :where(i) {
+    width: auto !important;
+}
+
+#undangan4x,
+#undangan4x :where(div),
+#undangan4x :where(nav),
+#undangan4x :where(svg),
+#undangan4x :where(section) {
+    will-change: background-color;
+    transition: background-color 350ms ease;
+}
+
+#undangan4x :where(svg>path) {
+    will-change: color;
+    transition: color 350ms ease;
+}
+
+html[data-bs-theme="dark"] #undangan4x :where(.navbar) {
+    background-color: rgba(var(--bs-dark-rgb), 0.75) !important;
+    backdrop-filter: blur(0.5rem);
+}
+
+html[data-bs-theme="light"] #undangan4x :where(.navbar) {
+    background-color: rgba(var(--bs-light-rgb), 0.75) !important;
+    backdrop-filter: blur(0.5rem);
+}
+
+html[data-bs-theme="dark"] #undangan4x :where(.text-theme-auto) {
+    color: rgb(var(--bs-light-rgb));
+}
+
+html[data-bs-theme="light"] #undangan4x :where(.text-theme-auto) {
+    color: rgb(var(--bs-dark-rgb));
+}
+
+html[data-bs-theme="dark"] #undangan4x :where(.nav-link) {
+    color: rgba(var(--bs-white-rgb), 0.5);
+}
+
+html[data-bs-theme="light"] #undangan4x :where(.nav-link) {
+    color: rgba(var(--bs-black-rgb), 0.5);
+}
+
+html[data-bs-theme="dark"] #undangan4x :where(.bg-theme-auto) {
+    background-color: var(--bs-gray-800);
+}
+
+html[data-bs-theme="light"] #undangan4x :where(.bg-theme-auto) {
+    background-color: var(--bs-gray-100);
+}
+
+html[data-bs-theme="dark"] #undangan4x :where(.btn-outline-auto) {
+    --bs-btn-color: var(--bs-light);
+    --bs-btn-border-color: var(--bs-light);
+    --bs-btn-hover-color: var(--bs-black);
+    --bs-btn-hover-bg: var(--bs-light);
+    --bs-btn-hover-border-color: var(--bs-light);
+    --bs-btn-focus-shadow-rgb: var(--bs-light-rgb);
+    --bs-btn-active-color: var(--bs-black);
+    --bs-btn-active-bg: var(--bs-light);
+    --bs-btn-active-border-color: var(--bs-light);
+    --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+    --bs-btn-disabled-color: var(--bs-light);
+    --bs-btn-disabled-bg: transparent;
+    --bs-btn-disabled-border-color: var(--bs-light);
+    --bs-gradient: none;
+}
+
+html[data-bs-theme="light"] #undangan4x :where(.btn-outline-auto) {
+    --bs-btn-color: var(--bs-dark);
+    --bs-btn-border-color: var(--bs-dark);
+    --bs-btn-hover-color: var(--bs-white);
+    --bs-btn-hover-bg: var(--bs-dark);
+    --bs-btn-hover-border-color: var(--bs-dark);
+    --bs-btn-focus-shadow-rgb: var(--bs-dark-rgb);
+    --bs-btn-active-color: var(--bs-white);
+    --bs-btn-active-bg: var(--bs-dark);
+    --bs-btn-active-border-color: var(--bs-dark);
+    --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+    --bs-btn-disabled-color: var(--bs-dark);
+    --bs-btn-disabled-bg: transparent;
+    --bs-btn-disabled-border-color: var(--bs-dark);
+    --bs-gradient: none;
+}
+
+html[data-bs-theme="dark"] #undangan4x :where(.bg-overlay-auto) {
+    background-color: rgba(var(--bs-black-rgb), 0.5);
+    backdrop-filter: blur(0.25rem);
+}
+
+html[data-bs-theme="light"] #undangan4x :where(.bg-overlay-auto) {
+    background-color: rgba(var(--bs-white-rgb), 0.5);
+    backdrop-filter: blur(0.25rem);
+}
+
+#undangan4x :where(.hover-area) {
+    display: none;
+    cursor: pointer;
+}
+
+#undangan4x :where(.hover-wrapper:hover .hover-area) {
+    display: flex;
+}
+
+#undangan4x :where(.gif-image) {
+    max-height: 10rem;
+}@import url("common.css");
+html #undangan4x {
+    scrollbar-width: none !important;
+    -ms-overflow-style: none !important;
+}
+
+#undangan4x :where(.with-scrollbar) {
+    scrollbar-width: auto !important;
+    -ms-overflow-style: auto !important;
+}
+
+#undangan4x :where(.font-esthetic) {
+    font-family: 'Sacramento', cursive !important;
+}
+
+#undangan4x :where(.font-arabic) {
+    font-family: 'Noto Naskh Arabic', serif !important;
+}
+
+#undangan4x :where(.img-center-crop) {
+    width: 13rem;
+    height: 13rem;
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: cover;
+}
+
+html[data-bs-theme="dark"] #undangan4x :where(.btn-transparent) {
+    background-color: rgba(var(--bs-dark-rgb), 0.5) !important;
+    backdrop-filter: blur(0.5rem);
+}
+
+html[data-bs-theme="light"] #undangan4x :where(.btn-transparent) {
+    background-color: rgba(var(--bs-light-rgb), 0.5) !important;
+    backdrop-filter: blur(0.5rem);
+}
+
+#undangan4x :where(.loading-page) {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1056;
+}
+
+html[data-bs-theme="light"] #undangan4x :where(.color-theme-svg) {
+    color: rgb(255, 255, 255);
+    background-color: var(--bs-light);
+}
+
+html[data-bs-theme="dark"] #undangan4x :where(.color-theme-svg) {
+    color: rgb(0, 0, 0);
+    background-color: var(--bs-dark);
+}
+
+html[data-bs-theme="light"] #undangan4x :where(.bg-light-dark) {
+    background-color: rgb(var(--bs-light-rgb));
+}
+
+html[data-bs-theme="dark"] #undangan4x :where(.bg-light-dark) {
+    background-color: rgb(var(--bs-dark-rgb));
+}
+
+html[data-bs-theme="light"] #undangan4x :where(.bg-white-black) {
+    background-color: rgb(var(--bs-white-rgb));
+}
+
+html[data-bs-theme="dark"] #undangan4x :where(.bg-white-black) {
+    background-color: rgb(var(--bs-black-rgb));
+}
+
+#undangan4x :where(.bg-cover-home) {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    mask-image: linear-gradient(0.5turn, transparent, black 40%, black 60%, transparent);
+}
+
+#undangan4x :where(.width-loading) {
+    width: 25%;
+}
+
+#undangan4x :where(.cursor-pointer) {
+    cursor: pointer;
+}
+
+@media screen and (max-width: 992px) {
+    #undangan4x :where(.width-loading) {
+        width: 50%;
+    }
+}
+
+@media screen and (max-width: 576px) {
+    #undangan4x :where(.width-loading) {
+        width: 75%;
+    }
+}
+
+#undangan4x :where(svg) {
+    display: block;
+    line-height: 0;
+    shape-rendering: geometricPrecision;
+    backface-visibility: hidden;
+}
+
+#undangan4x :where(.svg-wrapper) {
+    overflow: hidden !important;
+    transform: translateZ(0) !important;
+}
+
+#undangan4x :where(.no-gap-bottom) {
+    margin-bottom: -0.75rem !important;
+}

--- a/scripts/prefix-undangan4x.ts
+++ b/scripts/prefix-undangan4x.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env tsx
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import postcss, { type PluginCreator, type Root } from 'postcss';
+
+const SOURCE = path.resolve('public/themes/undangan-4x/css/undangan4x.css');
+const TARGET = path.resolve('public/themes/undangan-4x/css/undangan4x.scoped.css');
+const PREFIX = '#undangan4x';
+
+function transformSelector(selector: string) {
+  const trimmed = selector.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (trimmed.startsWith(PREFIX)) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith('html')) {
+    const match = trimmed.match(/^(html[^\s]*?)(\s+.+)?$/);
+    if (match) {
+      const [, htmlPart, rest] = match;
+      if (!rest) {
+        return `${htmlPart} ${PREFIX}`;
+      }
+      const scoped = rest.trim();
+      return `${htmlPart} ${PREFIX} :where(${scoped})`;
+    }
+  }
+
+  if (trimmed.startsWith('body')) {
+    const match = trimmed.match(/^(body[^\s]*?)(\s+.+)?$/);
+    if (match) {
+      const [, , rest] = match;
+      if (!rest) {
+        return PREFIX;
+      }
+      const scoped = rest.trim();
+      return `${PREFIX} :where(${scoped})`;
+    }
+  }
+
+  return `${PREFIX} :where(${trimmed})`;
+}
+
+const plugin: PluginCreator<void> = () => {
+  return {
+    postcssPlugin: 'prefix-undangan4x',
+    Once(root: Root) {
+      root.walkRules((rule) => {
+        const parent = rule.parent;
+        if (parent && parent.type === 'atrule') {
+          const name = parent.name?.toLowerCase();
+          if (name === 'keyframes' || name === 'font-face') {
+            return;
+          }
+        }
+
+        if (!rule.selectors) {
+          return;
+        }
+
+        rule.selectors = rule.selectors.map(transformSelector);
+      });
+    },
+  };
+};
+plugin.postcss = true;
+
+async function main() {
+  const css = await fs.readFile(SOURCE, 'utf8');
+  const result = await postcss([plugin()]).process(css, {
+    from: SOURCE,
+    to: TARGET,
+  });
+
+  await fs.mkdir(path.dirname(TARGET), { recursive: true });
+  await fs.writeFile(TARGET, result.css, 'utf8');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- scope the legacy undangan 4.x theme styles and script to the /undangan/[slug] route and wrap the page in the required container
- rebuild the invitation hero, sections, and bottom tab bar so the contoh-rahmat-nisa slug renders the undangan 4.x layout with Google Calendar and Maps actions
- add an automated script that prefixes the legacy CSS into a scoped variant and run it from postinstall to prevent theme leakage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5d1de023c83249d6877b72ec02b21