### PR TITLE
Silence lint warnings for undangan head and modal markup

### DIFF
--- a/app/undangan/[slug]/head.tsx
+++ b/app/undangan/[slug]/head.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-css-tags, @next/next/no-page-custom-font */
 export default function InvitationHead() {
   return (
     <>

--- a/app/undangan/[slug]/page.tsx
+++ b/app/undangan/[slug]/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 import { notFound } from 'next/navigation';
 import { Hero } from '@/components/legacy/Hero';
 import { SectionGaleri } from '@/components/legacy/SectionGaleri';


### PR DESCRIPTION
## Summary
- disable Next.js lint warnings in the undangan head file so Bootstrap and legacy fonts can load via link tags
- suppress the Next.js no-img-element warning on the undangan page to retain the gallery modal markup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5df6dd040832490268a4e09bc48c6