### PR TITLE
Fix guest theme script loading during build

### DIFF
--- a/app/undangan/[slug]/BodyAttributes.tsx
+++ b/app/undangan/[slug]/BodyAttributes.tsx
@@ -48,17 +48,30 @@ export default function BodyAttributes() {
 
     head.appendChild(bootstrap);
 
+    const guest = document.createElement('script');
+    guest.src = '/themes/undangan-4x/js/guest.js';
+    guest.async = true;
+    guest.defer = true;
+
     const guestPromise = bootstrapPromise
       .catch(() => undefined)
       .then(async () => {
-        await import(/* webpackIgnore: true */ '/themes/undangan-4x/js/guest.js');
+        const promise = new Promise<void>((resolve, reject) => {
+          guest.onload = () => resolve();
+          guest.onerror = () => reject(new Error('Failed to load guest script.'));
+        });
+
+        head.appendChild(guest);
+        await promise;
         window.dispatchEvent(new Event('load'));
-      });
+      })
+      .catch(() => undefined);
 
     void guestPromise;
 
     return () => {
       bootstrap.remove();
+      guest.remove();
 
       if (appendedThemeMeta) {
         appendedThemeMeta.remove();


### PR DESCRIPTION
## Summary
- load the undangan guest script via a dynamically appended script tag instead of an import
- clean up the injected guest script when the component unmounts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e603d5639c83249eb9037e1400410c