### PR TITLE
fix: load guest script as module

### DIFF
--- a/app/undangan/[slug]/BodyAttributes.tsx
+++ b/app/undangan/[slug]/BodyAttributes.tsx
@@ -50,6 +50,7 @@ export default function BodyAttributes() {
 
     const guest = document.createElement('script');
     guest.src = '/themes/undangan-4x/js/guest.js';
+    guest.type = 'module';
     guest.async = true;
     guest.defer = true;
 


### PR DESCRIPTION
## Summary
- ensure the guest invitation script is loaded as an ES module so its internal imports execute correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6054b24a0832480cc626f58a76e9f